### PR TITLE
Data Editor and Bofregistry minor enhancements for columns and sorting

### DIFF
--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
@@ -121,7 +121,7 @@ class AltinnEditorPrimaryTable:
 
         @callback(  # type: ignore[misc]
             Output("altinnedit-table-skjemadata", "rowData", allow_duplicate=True),
-            Output("altinnedit-table-skjemadata", "columnDefs",  allow_duplicate=True),
+            Output("altinnedit-table-skjemadata", "columnDefs", allow_duplicate=True),
             Input("altinnedit-refnr", "value"),
             Input("altinnedit-option1", "value"),
             State("altinnedit-skjemaer", "value"),
@@ -230,12 +230,18 @@ class AltinnEditorPrimaryTable:
                             "headerName": col,
                             "field": col,
                             "hide": col
-                            in ["row_id", "row_ids", *self.time_units, "skjema", "refnr"],
+                            in [
+                                "row_id",
+                                "row_ids",
+                                *self.time_units,
+                                "skjema",
+                                "refnr",
+                            ],
                         }
                         for col in df.columns
                     ]
                     return df.to_dict("records"), columndefs
-                    
+
                 except Exception as e:
                     logger.error(
                         f"Error in hovedside_update_altinnskjema (wide format): {e}",
@@ -243,9 +249,9 @@ class AltinnEditorPrimaryTable:
                     )
                     return None, None
 
-        try: # TODO Find better solution to sort - config file?
+        try:  # TODO Find better solution to sort - config file?
             self.variableselector.get_option("var-bedrift", search_target="id")
-            
+
             @callback(
                 Output("altinnedit-table-skjemadata", "rowData"),
                 Output("altinnedit-table-skjemadata", "columnDefs"),
@@ -255,24 +261,23 @@ class AltinnEditorPrimaryTable:
                 prevent_initial_call=True,
             )
             def sort_by_bedrift(
-                row_data: list[dict[str, Any]], 
-                column_defs: list[dict[str, Any]], 
-                bedrift: str
+                row_data: list[dict[str, Any]],
+                column_defs: list[dict[str, Any]],
+                bedrift: str,
             ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
                 """Sort table to prioritize selected bedrift."""
                 if not bedrift or not row_data:
                     return row_data, column_defs
-                
+
                 sorted_data = sorted(
-                row_data, 
-                key=lambda row: 0 if row.get("ident") == bedrift else 1
+                    row_data, key=lambda row: 0 if row.get("ident") == bedrift else 1
                 )
-                
+
                 return sorted_data, column_defs
-                
+
         except ValueError:
             logger.debug("var-bedrift not available, skipping bedrift sorting callback")
-        
+
         @callback(  # type: ignore[misc]
             Output("var-statistikkvariabel", "value"),
             Input("altinnedit-table-skjemadata", "cellClicked"),

--- a/src/ssb_dash_framework/modules/bofregistry.py
+++ b/src/ssb_dash_framework/modules/bofregistry.py
@@ -559,7 +559,6 @@ class BofInformation(ABC):
                             "field": col,
                             "checkboxSelection": col == "bedrifts_nr",
                             "headerCheckboxSelection": col == "bedrifts_nr",
-
                         }
                         for col in df.columns
                     ]
@@ -568,9 +567,9 @@ class BofInformation(ABC):
 
         logger.debug("Generated callbacks")
 
-        try: # TODO Find better solution to sort - config file?
-            VariableSelector([],[]).get_option("var-bedrift", search_target="id")
-            
+        try:  # TODO Find better solution to sort - config file?
+            VariableSelector([], []).get_option("var-bedrift", search_target="id")
+
             @callback(
                 Output("tab-bof_foretak-table1", "rowData"),
                 Output("tab-bof_foretak-table1", "columnDefs"),
@@ -587,15 +586,14 @@ class BofInformation(ABC):
                 """Sort bedrifter table to prioritize selected bedrift."""
                 if not bedrift or not row_data:
                     return row_data, column_defs
-                
+
                 # Sort directly without DataFrame conversion
                 sorted_data = sorted(
-                    row_data,
-                    key=lambda row: 0 if row.get("orgnr") == bedrift else 1
+                    row_data, key=lambda row: 0 if row.get("orgnr") == bedrift else 1
                 )
-                
+
                 return sorted_data, column_defs
-                
+
         except ValueError:
             logger.debug("var-bedrift not available, skipping bedrift sorting callback")
 

--- a/src/ssb_dash_framework/modules/macro_module.py
+++ b/src/ssb_dash_framework/modules/macro_module.py
@@ -535,7 +535,7 @@ class MacroModule:
             t_1 = t_1.select([*cols, "selected_nace"])
 
             # cast numerics to float in case of yearly type mismatches
-            for col in (HEATMAP_VARIABLES.keys()):
+            for col in HEATMAP_VARIABLES.keys():
                 if col in t.columns:
                     t = t.mutate(**{col: t[col].cast("float64")})
                 if col in t_1.columns:
@@ -803,7 +803,7 @@ class MacroModule:
             t_1 = t_1.rename(**rename_mapping)
 
             # cast numerics to float in case of yearly type mismatches
-            for col in (HEATMAP_VARIABLES.keys()):
+            for col in HEATMAP_VARIABLES.keys():
                 if col in t.columns:
                     t = t.mutate(**{col: t[col].cast("float64")})
                 if col in t_1.columns:
@@ -866,7 +866,11 @@ class MacroModule:
                 )
 
                 heatmap_value_change = cell_data.get("value", 0)
-                heatmap_value_change = float(heatmap_value_change) if heatmap_value_change != None else 0
+                heatmap_value_change = (
+                    float(heatmap_value_change)
+                    if heatmap_value_change is not None
+                    else 0
+                )
                 ascending_sorting_param: bool = heatmap_value_change < 0
                 df = df.sort_values(
                     f"{valgt_variabel}_diff", ascending=ascending_sorting_param


### PR DESCRIPTION
- Bofregistry - added type (reg_type) as a column for bedrifter in the tab module, and added var-bedrift as a state to sort bedrifter to get the selected one at the top
- MacroModule - added foretak and bedrift as required variables
- Added var-bedrift (if it exists) as a state to sort bedrifter in wide tables in the altinn editor, to get the selected one at the top