### PR TITLE
bedrift-sorting simplification and timezone fixes

### DIFF
--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_history.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_history.py
@@ -158,10 +158,7 @@ class AltinnEditorHistory:
                 if conn_is_ibis(self.conn):
                     conn = self.conn
                     t = conn.table("skjemadataendringshistorikk")
-                    df = (
-                        t.filter(_.refnr == refnr)
-                        .to_pandas()
-                    )
+                    df = t.filter(_.refnr == refnr).to_pandas()
                     df["endret_tid"] = (
                         pd.to_datetime(df["endret_tid"], utc=True)
                         .dt.tz_convert(local_tz)

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
@@ -134,12 +134,21 @@ class AltinnEditorPrimaryTable:
             Input("altinnedit-option1", "value"),
             Input("var-ident", "value"),
             State("altinnedit-skjemaer", "value"),
-            State("var-bedrift", "value") if has_bedrift else State("altinnedit-refnr", "value"),  # Dummy state if no bedrift
+            (
+                State("var-bedrift", "value")
+                if has_bedrift
+                else State("altinnedit-refnr", "value")
+            ),  # Dummy state if no bedrift
             self.variableselector.get_all_states(),
             prevent_initial_call=True,
         )
         def hovedside_update_altinnskjema(
-            refnr: str, tabell: str, ident: str, skjema: str, bedrift_or_dummy: str, *args: Any
+            refnr: str,
+            tabell: str,
+            ident: str,
+            skjema: str,
+            bedrift_or_dummy: str,
+            *args: Any,
         ) -> tuple[list[dict[str, Any]] | None, list[dict[str, Any]] | None]:
 
             # extract bedrift if it exists
@@ -193,10 +202,7 @@ class AltinnEditorPrimaryTable:
                         f"partition_select:\n{create_partition_select(desired_partitions=self.time_units,skjema=skjema,**partition_args,)}"
                     )
 
-                    t = (
-                        t.filter(_.refnr == refnr)
-                        .join(d, "variabel", how="left")
-                    )
+                    t = t.filter(_.refnr == refnr).join(d, "variabel", how="left")
                     t = t.filter(ibis_filter_with_dict(filter_dict))
 
                     # sort by bedrift if available
@@ -254,7 +260,7 @@ class AltinnEditorPrimaryTable:
                     if bedrift and "ident" in df.columns:
                         df = df.sort_values(
                             by="ident",
-                            key=lambda x: x.map(lambda v: 0 if v == bedrift else 1)
+                            key=lambda x: x.map(lambda v: 0 if v == bedrift else 1),
                         )
 
                     columndefs = [
@@ -290,17 +296,17 @@ class AltinnEditorPrimaryTable:
             click: dict[str, Any], row_data: list[dict[str, Any]]
         ) -> str:
             logger.debug(f"Args:\nclick: {click}\nrow_data: {row_data}")
-            
+
             if not click or not row_data:
                 raise PreventUpdate
 
             columns = list(row_data[0].keys())
-            
+
             long_format = "variabel" in columns and "verdi" in columns
             if long_format:
                 return str(row_data[click["rowIndex"]]["variabel"])
-            
-            column =  click.get("colId") # wide format
+
+            column = click.get("colId")  # wide format
             if column in ("aar", "ident", "skjema", "refnr", "tabell"):
                 raise PreventUpdate
 

--- a/src/ssb_dash_framework/modules/bofregistry.py
+++ b/src/ssb_dash_framework/modules/bofregistry.py
@@ -378,7 +378,9 @@ class BofInformation(ABC):
             has_bedrift = True
         except ValueError:
             has_bedrift = False
-            logger.debug("var-bedrift not available, skipping bedrift sorting in bof module")
+            logger.debug(
+                "var-bedrift not available, skipping bedrift sorting in bof module"
+            )
 
         @callback(  # type: ignore[misc]
             Output("bofregistry-modal-ssb_foretak", "is_open"),
@@ -443,7 +445,11 @@ class BofInformation(ABC):
             Output("bofregistry-ssb_bedrift-table", "columnDefs"),
             Input("tab-vof-foretak-button2", "n_clicks"),
             State("tab-bof_foretak-table1", "selectedRows"),
-            State("var-bedrift", "value") if has_bedrift else State("tab-bof_foretak-orgnrcard", "value"),  # dummy state if no bedrift
+            (
+                State("var-bedrift", "value")
+                if has_bedrift
+                else State("tab-bof_foretak-orgnrcard", "value")
+            ),  # dummy state if no bedrift
         )
         def ssb_bof_bedrift(
             n_clicks: int, selected_row: list[dict[str, Any]], bedrift_or_dummy: str
@@ -453,7 +459,7 @@ class BofInformation(ABC):
             )
             # Extract bedrift if it exists
             bedrift = bedrift_or_dummy if has_bedrift else None
-            
+
             orgnr = selected_row[0]["orgnr"]
             if n_clicks > 0:
                 conn = sqlite3.connect(SSB_BEDRIFT_PATH)
@@ -464,7 +470,7 @@ class BofInformation(ABC):
                 if bedrift:
                     df = df.sort_values(
                         by="orgnr",
-                        key=lambda x: x.map(lambda v:0 if v == bedrift else 1)
+                        key=lambda x: x.map(lambda v: 0 if v == bedrift else 1),
                     )
                 columns = [
                     {
@@ -576,6 +582,7 @@ class BofInformation(ABC):
                 return df.to_dict("records"), columns
 
         logger.debug("Generated callbacks")
+
 
 class BofInformationTab(TabImplementation, BofInformation):
     """A class to implement a bof information module as a tab."""

--- a/src/ssb_dash_framework/modules/macro_module.py
+++ b/src/ssb_dash_framework/modules/macro_module.py
@@ -766,7 +766,7 @@ class MacroModule:
             if macro_level != "sammensatte variabler":
 
                 assert isinstance(macro_level, str)
-                
+
                 col_length: int = MACRO_FILTER_OPTIONS[macro_level]
                 t_curr_filtered = t_curr_filtered.mutate(
                     **{
@@ -887,12 +887,8 @@ class MacroModule:
                 indicator=True,
             )
 
-            merged_df["is_new"] = (
-                merged_df["_merge"] == "left_only"
-            )
-            merged_df["is_exiter"] = (
-                merged_df["_merge"] == "right_only"
-            )
+            merged_df["is_new"] = merged_df["_merge"] == "left_only"
+            merged_df["is_exiter"] = merged_df["_merge"] == "right_only"
 
             # for exiters, fill in key identifying columns from previous year
             if "navn" in merged_df.columns and "navn_x" in merged_df.columns:
@@ -911,13 +907,13 @@ class MacroModule:
                     merged_df[f"{naring_col}_x"].astype(str).str[:nace_siffer_level]
                 )
 
-                merged_df["is_nace_entrant"] = ( # different nace LAST year
+                merged_df["is_nace_entrant"] = (  # different nace LAST year
                     ~merged_df["is_new"]
                     & (merged_df["nace_prefix_curr"] == selected_nace)
                     & (merged_df["nace_prefix_prev"] != selected_nace)
                 )
 
-                merged_df["is_nace_exiter"] = ( # different nace THIS year
+                merged_df["is_nace_exiter"] = (  # different nace THIS year
                     ~merged_df["is_exiter"]
                     & (merged_df["nace_prefix_prev"] == selected_nace)
                     & (merged_df["nace_prefix_curr"] != selected_nace)
@@ -1162,7 +1158,7 @@ class MacroModule:
 
             clicked_row = rowdata[row_idx]
             bedrift = ""
-            
+
             if col_id in ("orgnr_f", "navn"):
                 tabell = "skjemadata_foretak"
             elif col_id == "orgnr_b":
@@ -1173,7 +1169,11 @@ class MacroModule:
 
             ident = clicked_row.get("orgnr_f", "")
 
-            return str(ident) if ident else "", str(bedrift) if bedrift else "", str(tabell) if tabell else ""
+            return (
+                str(ident) if ident else "",
+                str(bedrift) if bedrift else "",
+                str(tabell) if tabell else "",
+            )
 
 
 class MacroModuleTab(TabImplementation, MacroModule):


### PR DESCRIPTION
- macromodule: variabelvelger output fix
- bofregistry & altinn primary table: dropped the callback that sorts bedrift according to var-bedrift and moved it into the main code by creating a real/dummy state (depending on if var-bedrift exists) which sorts the ag grid created by this variable
- altinn primary table: added "var-ident" as an Input so the grid is rendered again if ident changes
- fixed timezone awareness in altinn history table, so it doesn't return UTC but instead UTC+1