### PR TITLE
bofregistry updates, alert handler updates and altinn editor alert fixes

### DIFF
--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -56,7 +56,7 @@ Alert handler
 .alert-modal-item {
     padding: 10px !important;
     min-width: 500px;
-    max-width: 900px;
+    max-width: 1000px;
     border-radius: 8px;
     border: 1px solid var(--bs-alert-border-color);
 }

--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -53,9 +53,11 @@ Alert handler
 
 .alert-toast,
 .alert-modal-item {
-    padding: 10px 10px !important;
+    padding: 10px !important;
     min-width: 500px;
     max-width: 900px;
+    border-radius: 8px;
+    border: 1px solid var(--bs-alert-border-color);
 }
 
 .alert-icon {
@@ -80,17 +82,6 @@ Alert handler
     left: 10px;
 }
 
-.alert-container.bottom-left .alert.alert-toast {
-    animation: slideInLeft 0.2s ease-out;
-    border-radius: 8px;
-    border: 1px solid var(--bs-alert-border-color);
-}
-
-@keyframes slideInLeft {
-    from { transform: translateX(-110%); opacity: 0; }
-    to   { transform: translateX(0);     opacity: 1; }
-}
-
 .alert-container.top-right {
     top: 10px;
     right: 10px;
@@ -103,10 +94,14 @@ Alert handler
     z-index: 3000;
 }
 
-.alert-container.center .alert.alert-toast {
-    animation: fadeIn 0.3s ease-out;
-    border-radius: 12px;
-    border: 1px solid var(--bs-alert-border-color);
+@keyframes slideInLeft {
+    from { transform: translateX(-110%); opacity: 0; }
+    to   { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(110%); opacity: 0; }
+    to   { transform: translateX(0); opacity: 1; }
 }
 
 @keyframes fadeIn {
@@ -114,24 +109,29 @@ Alert handler
     to   { opacity: 1; }
 }
 
-.alert-container.top-right .alert.alert-toast {
-    animation: slideInRight 0.2s ease-out;
-    border-radius: 8px;
-    border: 1px solid var(--bs-alert-border-color);
-}
-
-@keyframes slideInRight {
-    from { transform: translateX(110%); opacity: 0; }
-    to   { transform: translateX(0);    opacity: 1; }
-}
-
-.alert-container .alert.alert-toast.alert-dying {
-    animation: fadeOut 0.4s ease-in forwards;
-}
-
 @keyframes fadeOut {
     from { opacity: 1; }
     to   { opacity: 0; }
+}
+
+/* Left */
+.alert-container.bottom-left .alert.alert-toast {
+    animation: slideInLeft 0.2s ease-out;
+}
+
+/* Right */
+.alert-container.top-right .alert.alert-toast {
+    animation: slideInRight 0.2s ease-out;
+}
+
+/* Center */
+.alert-container.center .alert.alert-toast {
+    animation: fadeIn 0.3s ease-out;
+}
+
+/* Exit animation */
+.alert-container .alert.alert-toast.alert-dying {
+    animation: fadeOut 0.4s ease-in forwards;
 }
 
 /*
@@ -307,8 +307,8 @@ Bofregistry
 Altinn Editor History
 */
 .history-modal .modal-dialog {
-    max-width: 70vw !important;
-    width: 80vw !important;
+    max-width: 90vw !important;
+    width: 90vw !important;
 }
 
 .history-modal .modal-content {
@@ -319,6 +319,7 @@ Altinn Editor History
 /*
 Altinn Editor Support Tables
 */
+
 .hjelpetabeller-modal .modal-dialog {
     max-width: 90vw !important;
     width: 90vw !important;

--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -44,8 +44,94 @@ Alert handler
 .alert-container {
     position: fixed;
     z-index: 2000;
+    pointer-events: none;
+}
+
+.alert-container .alert {
+    pointer-events: auto; /* but actual alerts are still clickable/dismissable */
+}
+
+.alert-toast,
+.alert-modal-item {
+    padding: 10px 10px !important;
+    min-width: 500px;
+    max-width: 900px;
+}
+
+.alert-icon {
+    font-size: 1.5rem;
+    filter: brightness(6);
+}
+
+.alert-message {
+    font-size: 1rem;
+    font-weight: 500;
+}
+.alert-message p {
+    margin: 0;
+}
+
+.alert-timestamp {
+    font-size: 1rem;
+}
+
+.alert-container.bottom-left {
     bottom: 10px;
     left: 10px;
+}
+
+.alert-container.bottom-left .alert.alert-toast {
+    animation: slideInLeft 0.2s ease-out;
+    border-radius: 8px;
+    border: 1px solid var(--bs-alert-border-color);
+}
+
+@keyframes slideInLeft {
+    from { transform: translateX(-110%); opacity: 0; }
+    to   { transform: translateX(0);     opacity: 1; }
+}
+
+.alert-container.top-right {
+    top: 10px;
+    right: 10px;
+}
+
+.alert-container.center {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 3000;
+}
+
+.alert-container.center .alert.alert-toast {
+    animation: fadeIn 0.3s ease-out;
+    border-radius: 12px;
+    border: 1px solid var(--bs-alert-border-color);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.alert-container.top-right .alert.alert-toast {
+    animation: slideInRight 0.2s ease-out;
+    border-radius: 8px;
+    border: 1px solid var(--bs-alert-border-color);
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(110%); opacity: 0; }
+    to   { transform: translateX(0);    opacity: 1; }
+}
+
+.alert-container .alert.alert-toast.alert-dying {
+    animation: fadeOut 0.4s ease-in forwards;
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to   { opacity: 0; }
 }
 
 /*

--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -48,7 +48,8 @@ Alert handler
 }
 
 .alert-container .alert {
-    pointer-events: auto; /* but actual alerts are still clickable/dismissable */
+    pointer-events: auto;
+    /* but actual alerts are still clickable/dismissable */
 }
 
 .alert-toast,
@@ -69,6 +70,7 @@ Alert handler
     font-size: 1rem;
     font-weight: 500;
 }
+
 .alert-message p {
     margin: 0;
 }
@@ -95,23 +97,47 @@ Alert handler
 }
 
 @keyframes slideInLeft {
-    from { transform: translateX(-110%); opacity: 0; }
-    to   { transform: translateX(0); opacity: 1; }
+    from {
+        transform: translateX(-110%);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
 }
 
 @keyframes slideInRight {
-    from { transform: translateX(110%); opacity: 0; }
-    to   { transform: translateX(0); opacity: 1; }
+    from {
+        transform: translateX(110%);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
 }
 
 @keyframes fadeOut {
-    from { opacity: 1; }
-    to   { opacity: 0; }
+    from {
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+    }
 }
 
 /* Left */
@@ -256,9 +282,7 @@ AltinnDataCapture
     width: 100%;
 }
 
-.altinn-data-capture-loading {
-
-}
+.altinn-data-capture-loading {}
 
 /*
 Bofregistry
@@ -339,6 +363,7 @@ Altinn Editor Support Tables
     height: 80vh !important;
     overflow: hidden;
 }
+
 /*
 MacroModule
 */
@@ -475,12 +500,12 @@ Figuredisplay
 */
 
 .figuredisplay {
-    height:100%;
+    height: 100%;
     width: 100%;
 }
 
 .figuredisplay-graph {
-    height:100%;
+    height: 100%;
     width: 100%;
 }
 
@@ -525,7 +550,8 @@ Tables
 }
 
 .editingtable-aggrid-style {
-    height: 100% !important; /* For some reason this needed !important to work. */
+    height: 100% !important;
+    /* For some reason this needed !important to work. */
     width: 100%;
 }
 

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_history.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_history.py
@@ -175,6 +175,12 @@ class AltinnEditorHistory:
                             "field": col,
                             "filter": True,
                             "resizable": True,
+                            "hide": col
+                                in [
+                                    *self.time_units,
+                                    "skjema",
+                                    "refnr",
+                                ],
                         }
                         for col in df.columns
                     ]
@@ -201,6 +207,12 @@ class AltinnEditorHistory:
                             "field": col,
                             "filter": True,
                             "resizable": True,
+                            "hide": col
+                                in [
+                                    *self.time_units,
+                                    "skjema",
+                                    "refnr",
+                                ],
                         }
                         for col in df.columns
                     ]

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_history.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_history.py
@@ -176,11 +176,11 @@ class AltinnEditorHistory:
                             "filter": True,
                             "resizable": True,
                             "hide": col
-                                in [
-                                    *self.time_units,
-                                    "skjema",
-                                    "refnr",
-                                ],
+                            in [
+                                *self.time_units,
+                                "skjema",
+                                "refnr",
+                            ],
                         }
                         for col in df.columns
                     ]
@@ -208,11 +208,11 @@ class AltinnEditorHistory:
                             "filter": True,
                             "resizable": True,
                             "hide": col
-                                in [
-                                    *self.time_units,
-                                    "skjema",
-                                    "refnr",
-                                ],
+                            in [
+                                *self.time_units,
+                                "skjema",
+                                "refnr",
+                            ],
                         }
                         for col in df.columns
                     ]

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
@@ -377,7 +377,7 @@ class AltinnEditorPrimaryTable:
                             else:
                                 alert_store = [
                                     create_alert(
-                                        f"ident: {ident}, variabel: {variable} er oppdatert fra **{old_value}** til **{value}**!",
+                                        f"ident: {ident}, variabel: {variable} er oppdatert fra {old_value} til {value}!",
                                         "success",
                                         ephemeral=True,
                                     ),
@@ -423,7 +423,7 @@ class AltinnEditorPrimaryTable:
                             else:
                                 alert_store = [
                                     create_alert(
-                                        f"ident: {ident}, {edited_column} er oppdatert fra **{old_value}** til **{value}**!",
+                                        f"ident: {ident}, {edited_column} er oppdatert fra {old_value} til {value}!",
                                         "success",
                                         ephemeral=True,
                                     ),
@@ -485,7 +485,7 @@ class AltinnEditorPrimaryTable:
                             variabel = edited[0]["data"]["variabel"]
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, variabel: {variabel} er oppdatert fra **{old_value}** til **{new_value}**!",
+                                    f"ident: {ident}, variabel: {variabel} er oppdatert fra {old_value} til {new_value}!",
                                     "success",
                                     ephemeral=True,
                                 ),
@@ -494,7 +494,7 @@ class AltinnEditorPrimaryTable:
                         else:
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, {edited_column} er oppdatert fra **{old_value}** til **{new_value}**!",
+                                    f"ident: {ident}, {edited_column} er oppdatert fra {old_value} til {new_value}!",
                                     "success",
                                     ephemeral=True,
                                 ),

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
@@ -343,7 +343,7 @@ class AltinnEditorPrimaryTable:
                             conn.raw_sql(query)
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, variabel: {variable} er oppdatert fra {old_value} til {value}!",
+                                    f"ident: {ident}, variabel: {variable} er oppdatert fra **{old_value}** til **{value}**!",
                                     "success",
                                     ephemeral=True,
                                 ),
@@ -362,7 +362,7 @@ class AltinnEditorPrimaryTable:
                             conn.raw_sql(query)
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, {variable} er oppdatert fra {old_value} til {value}!",
+                                    f"ident: {ident}, {variable} er oppdatert fra **{old_value}** til **{value}**!",
                                     "success",
                                     ephemeral=True,
                                 ),
@@ -417,7 +417,7 @@ class AltinnEditorPrimaryTable:
                             variabel = edited[0]["data"]["variabel"]
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, variabel: {variabel} er oppdatert fra {old_value} til {new_value}!",
+                                    f"ident: {ident}, variabel: {variabel} er oppdatert fra **{old_value}** til **{new_value}**!",
                                     "success",
                                     ephemeral=True,
                                 ),
@@ -426,7 +426,7 @@ class AltinnEditorPrimaryTable:
                         else:
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, {edited_column} er oppdatert fra {old_value} til {new_value}!",
+                                    f"ident: {ident}, {edited_column} er oppdatert fra **{old_value}** til **{new_value}**!",
                                     "success",
                                     ephemeral=True,
                                 ),

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
@@ -275,9 +275,10 @@ class AltinnEditorPrimaryTable:
             Output("var-statistikkvariabel", "value"),
             Input("altinnedit-table-skjemadata", "cellClicked"),
             State("altinnedit-table-skjemadata", "rowData"),
+            State("var-statistikkvariabel", "value"),
         )
         def select_variabel(
-            click: dict[str, Any], row_data: list[dict[str, Any]]
+            click: dict[str, Any], row_data: list[dict[str, Any]], statistikkvariabel: str
         ) -> str:
             logger.debug(f"Args:\nclick: {click}\nrow_data: {row_data}")
 
@@ -288,9 +289,15 @@ class AltinnEditorPrimaryTable:
 
             long_format = "variabel" in columns and "verdi" in columns
             if long_format:
-                return str(row_data[click["rowIndex"]]["variabel"])
+                variable = str(row_data[click["rowIndex"]]["variabel"])
+                if variable == statistikkvariabel:
+                    raise PreventUpdate
+                return variable
 
             column = click.get("colId")  # wide format
+            if column == statistikkvariabel:
+                raise PreventUpdate
+            
             if column in ("aar", "ident", "skjema", "refnr", "tabell"):
                 raise PreventUpdate
 
@@ -332,7 +339,22 @@ class AltinnEditorPrimaryTable:
                     old_value = edited[0]["oldValue"]
                     condition_str = " AND ".join(period_where)
                     columns = conn.table(tabell).columns
+
+                    ILLEGAL_COLUMNS = {"id", "ident", "refnr", "skjema", "variabel"}
+                    edited_column = edited[0]["colId"]
+
                     if "variabel" in columns and "verdi" in columns:
+                        # long format
+                        if edited_column != "verdi":
+                            alert_store = [
+                                create_alert(
+                                    f"Kolonnen {edited_column} kan ikke editeres!",
+                                    "danger",
+                                    ephemeral=True,
+                                ),
+                                *alert_store,
+                            ]
+                            return alert_store
                         try:
                             variable = edited[0]["data"]["variabel"]
                             query = f"""
@@ -340,36 +362,80 @@ class AltinnEditorPrimaryTable:
                                 SET verdi = '{value}'
                                 WHERE variabel = '{variable}' AND ident = '{ident}' AND refnr = '{refnr}' AND {condition_str}
                             """
-                            conn.raw_sql(query)
+                            result = conn.raw_sql(query)
+                            if result.rowcount == 0:
+                                alert_store = [
+                                    create_alert(
+                                        f"Oppdateringa gikk ikke gjennom (ingen rader påvirket).",
+                                        "danger",
+                                        ephemeral=True,
+                                    ),
+                                    *alert_store,
+                                ]
+                            else:
+                                alert_store = [
+                                    create_alert(
+                                        f"ident: {ident}, variabel: {variable} er oppdatert fra **{old_value}** til **{value}**!",
+                                        "success",
+                                        ephemeral=True,
+                                    ),
+                                    *alert_store,
+                                ]
+                        except Exception as e:
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, variabel: {variable} er oppdatert fra **{old_value}** til **{value}**!",
-                                    "success",
+                                    f"Oppdateringa feilet: {str(e)[:120]}",
+                                    "danger",
                                     ephemeral=True,
                                 ),
                                 *alert_store,
                             ]
-                        except Exception as e:
-                            raise e
                     else:
+                        # wide format
+                        if edited_column in ILLEGAL_COLUMNS:
+                                alert_store = [
+                                    create_alert(
+                                        f"Kolonnen {edited_column} kan ikke editeres!",
+                                        "danger",
+                                        ephemeral=True,
+                                    ),
+                                    *alert_store,
+                                ]
+                                return alert_store
                         try:
-                            variable = edited[0]["colId"]
                             query = f"""
                                 UPDATE {tabell}
-                                SET {variable} = '{value}'
+                                SET {edited_column} = '{value}'
                                 WHERE ident = '{ident}' AND refnr = '{refnr}' AND {condition_str}
                             """
-                            conn.raw_sql(query)
+                            result = conn.raw_sql(query)
+                            if result.rowcount == 0:
+                                alert_store = [
+                                    create_alert(
+                                        f"Oppdateringa gikk ikke gjennom (ingen rader påvirket).",
+                                        "danger",
+                                        ephemeral=True,
+                                    ),
+                                    *alert_store,
+                                ]
+                            else:
+                                alert_store = [
+                                    create_alert(
+                                        f"ident: {ident}, {edited_column} er oppdatert fra **{old_value}** til **{value}**!",
+                                        "success",
+                                        ephemeral=True,
+                                    ),
+                                    *alert_store,
+                                ]
+                        except Exception as e:
                             alert_store = [
                                 create_alert(
-                                    f"ident: {ident}, {variable} er oppdatert fra **{old_value}** til **{value}**!",
-                                    "success",
+                                    f"Oppdateringa feilet. {str(e)[:120]}",
+                                    "danger",
                                     ephemeral=True,
                                 ),
                                 *alert_store,
                             ]
-                        except Exception as e:
-                            raise e
                     return alert_store
 
             elif isinstance(connection_object, EimerDBInstance):

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_primary_table.py
@@ -278,7 +278,9 @@ class AltinnEditorPrimaryTable:
             State("var-statistikkvariabel", "value"),
         )
         def select_variabel(
-            click: dict[str, Any], row_data: list[dict[str, Any]], statistikkvariabel: str
+            click: dict[str, Any],
+            row_data: list[dict[str, Any]],
+            statistikkvariabel: str,
         ) -> str:
             logger.debug(f"Args:\nclick: {click}\nrow_data: {row_data}")
 
@@ -297,7 +299,7 @@ class AltinnEditorPrimaryTable:
             column = click.get("colId")  # wide format
             if column == statistikkvariabel:
                 raise PreventUpdate
-            
+
             if column in ("aar", "ident", "skjema", "refnr", "tabell"):
                 raise PreventUpdate
 
@@ -393,15 +395,15 @@ class AltinnEditorPrimaryTable:
                     else:
                         # wide format
                         if edited_column in ILLEGAL_COLUMNS:
-                                alert_store = [
-                                    create_alert(
-                                        f"Kolonnen {edited_column} kan ikke editeres!",
-                                        "danger",
-                                        ephemeral=True,
-                                    ),
-                                    *alert_store,
-                                ]
-                                return alert_store
+                            alert_store = [
+                                create_alert(
+                                    f"Kolonnen {edited_column} kan ikke editeres!",
+                                    "danger",
+                                    ephemeral=True,
+                                ),
+                                *alert_store,
+                            ]
+                            return alert_store
                         try:
                             query = f"""
                                 UPDATE {tabell}

--- a/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_supporting_table.py
+++ b/src/ssb_dash_framework/modules/altinn_editor/altinn_editor_supporting_table.py
@@ -83,7 +83,7 @@ class AltinnSupportTable:
                 defaultColDef={"editable": False, "filter": True},
                 dashGridOptions={"enableCellTextSelection": True},
                 id=f"support-table-{self.suptable_id}",
-                style={"height": "700px"},
+                style={"height": "400px"},
             )
         )
 

--- a/src/ssb_dash_framework/modules/bofregistry.py
+++ b/src/ssb_dash_framework/modules/bofregistry.py
@@ -13,6 +13,7 @@ from dash.dependencies import Input
 from dash.dependencies import Output
 from dash.dependencies import State
 from dash.exceptions import PreventUpdate
+from sqlalchemy.util.typing import NoneType
 
 from ..setup.variableselector import VariableSelector
 from ..utils import TabImplementation
@@ -23,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 SSB_FORETAK_PATH = "/buckets/shared/vof/oracle-hns/ssb_foretak.db"
 SSB_BEDRIFT_PATH = "/buckets/shared/vof/oracle-hns/ssb_bedrift.db"
-
 
 def ssb_foretak_modal() -> dbc.Modal:
     """Create a modal for displaying bof data.
@@ -146,16 +146,16 @@ class BofInformation(ABC):
             )
 
     def _check_connection(self) -> None:
-        conn = sqlite3.connect(SSB_FORETAK_PATH)
-        df = pd.read_sql_query("SELECT * FROM ssb_foretak LIMIT 1", conn)
+        with sqlite3.connect(SSB_FORETAK_PATH) as conn:
+            df = pd.read_sql_query("SELECT * FROM ssb_foretak LIMIT 1", conn)
         if df.empty:
             raise Exception(
                 "Data from ssb_bedrift is empty, check that you can connect to the database. You need to add the oracle-hns bucket to your Dapla Lab."
             )
         conn.close()
 
-        conn = sqlite3.connect(SSB_BEDRIFT_PATH)
-        df = pd.read_sql_query("SELECT * FROM ssb_bedrift LIMIT 1", conn)
+        with sqlite3.connect(SSB_BEDRIFT_PATH) as conn:
+            df = pd.read_sql_query("SELECT * FROM ssb_bedrift LIMIT 1", conn)
         if df.empty:
             raise Exception(
                 "Data from ssb_bedrift is empty, check that you can connect to the database."
@@ -198,7 +198,7 @@ class BofInformation(ABC):
                     [
                         dbc.Col(
                             self.generate_card(
-                                "Orgnr",
+                                "orgnr",
                                 "tab-bof_foretak-orgnrcard",
                                 "text",
                             ),
@@ -206,11 +206,19 @@ class BofInformation(ABC):
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Navn",
+                                "foretaks_nr",
+                                "tab-bof_foretak-foretaksnrcard",
+                                "text",
+                            ),
+                            width=2,
+                        ),
+                        dbc.Col(
+                            self.generate_card(
+                                "navn",
                                 "tab-bof_foretak-navncard",
                                 "text",
                             ),
-                            width=10,
+                            width=8,
                         ),
                     ],
                     className="mb-2",
@@ -219,32 +227,44 @@ class BofInformation(ABC):
                     [
                         dbc.Col(
                             self.generate_card(
-                                "foretaks_nr",
-                                "tab-bof_foretak-foretaksnrcard",
+                                "nace (SN) 2007",
+                                "tab-bof_foretak-nace-sn07-card",
                                 "text",
                             ),
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Nace",
-                                "tab-bof_foretak-nacecard",
+                                "nace (SN) 2025",
+                                "tab-bof_foretak-nace-sn25-card",
                                 "text",
                             ),
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Statuskode",
+                                "statuskode",
                                 "tab-bof_foretak-statuscard",
                                 "text",
                             ),
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Sektor 2014",
+                                "sektor 2014",
                                 "tab-bof_foretak-sektorcard",
                                 "text",
                             ),
                         ),
+                        dbc.Col(
+                            self.generate_card(
+                                "organisasjonsform",
+                                "tab-bof_foretak-orgformcard",
+                                "text",
+                            ),
+                        ),
+                    ],
+                    className="mb-2",
+                ),
+                dbc.Row(
+                    [
                         dbc.Col(
                             self.generate_card(
                                 "omsetning",
@@ -252,42 +272,30 @@ class BofInformation(ABC):
                                 "text",
                             ),
                         ),
-                    ],
-                    className="mb-2",
-                ),
-                dbc.Row(
-                    [
                         dbc.Col(
                             self.generate_card(
-                                "Organisasjonsform",
-                                "tab-bof_foretak-orgformcard",
-                                "text",
-                            ),
-                        ),
-                        dbc.Col(
-                            self.generate_card(
-                                "Ansatte",
+                                "ansatte",
                                 "tab-bof_foretak-ansattecard",
                                 "text",
                             ),
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Ansatte tot.",
+                                "ansatte tot.",
                                 "tab-bof_foretak-totansattecard",
                                 "text",
                             ),
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Kommunenummer",
+                                "kommunenummer",
                                 "tab-bof_foretak-kommunecard",
                                 "text",
                             ),
                         ),
                         dbc.Col(
                             self.generate_card(
-                                "Type",
+                                "type",
                                 "tab-bof_foretak-typecard",
                                 "text",
                             ),
@@ -387,16 +395,15 @@ class BofInformation(ABC):
             Input("tab-vof-foretak-button1", "n_clicks"),
             State("bofregistry-modal-ssb_foretak", "is_open"),
         )
-        def toggle_bof_modal(n_clicks: int, is_open: bool) -> bool:
+        def toggle_bof_modal(n_clicks: int | None, is_open: bool) -> bool:
             logger.debug("Args:\n" + f"n_clicks: {n_clicks}\n" + f"is_open: {is_open}")
-            if n_clicks > 0:
-                if is_open:
-                    return False
-                else:
-                    return True
-            else:
+            if n_clicks is None:
                 logger.debug("Raised PreventUpdate")
                 raise PreventUpdate
+            if is_open:
+                return False
+            else:
+                return True
 
         @callback(  # type: ignore[misc]
             Output("bofregistry-modal-ssb_bedrift", "is_open"),
@@ -405,13 +412,13 @@ class BofInformation(ABC):
         )
         def toggle_bedrift_modal(n_clicks: int, is_open: bool) -> bool:
             logger.debug("Args:\n" + f"n_clicks: {n_clicks}\n" + f"is_open: {is_open}")
-            if n_clicks > 0:
-                if is_open:
-                    return False
-                else:
-                    return True
-            logger.debug("Raised PreventUpdate")
-            raise PreventUpdate
+            if n_clicks is None:
+                logger.debug("Raised PreventUpdate")
+                raise PreventUpdate
+            if is_open:
+                return False
+            else:
+                return True
 
         @callback(  # type: ignore[misc]
             Output("bofregistry-ssb_foretak-table", "rowData"),
@@ -420,25 +427,27 @@ class BofInformation(ABC):
             State("tab-bof_foretak-orgnrcard", "value"),
         )
         def ssb_bof_foretak(
-            n_clicks: int, orgnr: str
+            n_clicks: int | None, orgnr: str
         ) -> tuple[list[dict[Any, Any]], list[dict[str, Any]]]:
             logger.debug("Args:\n" + f"n_clicks: {n_clicks}\n" + f"orgnr: {orgnr}")
-            if n_clicks > 0:
-                conn = sqlite3.connect(SSB_FORETAK_PATH)
+            if n_clicks is None:
+                logger.debug("Raised PreventUpdate")
+                raise PreventUpdate
+                
+            with sqlite3.connect(SSB_FORETAK_PATH) as conn:
                 df = pd.read_sql_query(
                     f"SELECT * FROM ssb_foretak WHERE orgnr = '{orgnr}'", conn
                 )
-                df = df.melt()
-                columns = [
-                    {
-                        "headerName": col,
-                        "field": col,
-                    }
-                    for col in df.columns
-                ]
-                return df.to_dict("records"), columns
-            logger.debug("Raised PreventUpdate")
-            raise PreventUpdate
+                print(df.head())
+            df = df.melt()
+            columns = [
+                {
+                    "headerName": col,
+                    "field": col,
+                }
+                for col in df.columns
+            ]
+            return df.to_dict("records"), columns
 
         @callback(  # type: ignore[misc]
             Output("bofregistry-ssb_bedrift-table", "rowData"),
@@ -447,35 +456,37 @@ class BofInformation(ABC):
             State("tab-bof_foretak-table1", "selectedRows"),
         )
         def ssb_bof_bedrift(
-            n_clicks: int,
+            n_clicks: int | None,
             selected_row: list[dict[str, Any]],
         ) -> tuple[list[dict[Any, Any]], list[dict[str, Any]]]:
             logger.debug(
                 "Args:\n" + f"n_clicks: {n_clicks}\n" + f"selected_row: {selected_row}"
             )
+            if n_clicks is None or not selected_row:
+                logger.debug("Raised PreventUpdate")
+                raise PreventUpdate
+
             orgnr = selected_row[0]["orgnr"]
-            if n_clicks > 0:
-                conn = sqlite3.connect(SSB_BEDRIFT_PATH)
+            with sqlite3.connect(SSB_BEDRIFT_PATH) as conn:
                 df = pd.read_sql_query(
                     f"SELECT * FROM ssb_bedrift WHERE orgnr = '{orgnr}'", conn
                 )
-                df = df.melt()
+            df = df.melt()
 
-                columns = [
-                    {
-                        "headerName": col,
-                        "field": col,
-                    }
-                    for col in df.columns
-                ]
-                return df.to_dict("records"), columns
-            logger.debug("Raised PreventUpdate")
-            raise PreventUpdate
+            columns = [
+                {
+                    "headerName": col,
+                    "field": col,
+                }
+                for col in df.columns
+            ]
+            return df.to_dict("records"), columns
 
         @callback(  # type: ignore[misc]
             Output("tab-bof_foretak-orgnrcard", "value"),
             Output("tab-bof_foretak-navncard", "value"),
-            Output("tab-bof_foretak-nacecard", "value"),
+            Output("tab-bof_foretak-nace-sn07-card", "value"),
+            Output("tab-bof_foretak-nace-sn25-card", "value"),
             Output("tab-bof_foretak-statuscard", "value"),
             Output("tab-bof_foretak-ansattecard", "value"),
             Output("tab-bof_foretak-sektorcard", "value"),
@@ -489,7 +500,7 @@ class BofInformation(ABC):
         )
         def bof_data(
             orgf: str,
-        ) -> tuple[str, str, str, str, int, str, str, str, str, int, str, str]:
+        ) -> tuple[str, str, str, str, str, int, str, str, str, str, int, str, str]:
             """Fetch BoF Foretak data based on the selected organization number.
 
             Args:
@@ -504,17 +515,18 @@ class BofInformation(ABC):
             """
             logger.debug("Args:\n" + f"orgf: {orgf}")
             if orgf is not None:
-                conn = sqlite3.connect(SSB_FORETAK_PATH)
-                df = pd.read_sql_query(
-                    f"SELECT * FROM ssb_foretak WHERE orgnr = '{orgf}'",
-                    conn,
-                )
+                with sqlite3.connect(SSB_FORETAK_PATH) as conn:
+                    df = pd.read_sql_query(
+                        f"SELECT * FROM ssb_foretak WHERE orgnr = '{orgf}'",
+                        conn,
+                    )
 
                 df["ansatte_totalt"] = df["ansatte_totalt"].fillna(0)
 
                 orgnr = df["orgnr"][0]
                 navn = df["navn"][0]
-                nace = df["sn07_1"][0]
+                nace_07 = df["sn07_1"][0]
+                nace_2025 = df["sn2025_1"][0]
                 statuskode = df["statuskode"][0]
                 ansatte = df["antall_ansatte"][0]
                 sektor = df["sektor_2014"][0]
@@ -527,7 +539,8 @@ class BofInformation(ABC):
                 return (
                     orgnr,
                     navn,
-                    nace,
+                    nace_07,
+                    nace_2025,
                     statuskode,
                     ansatte,
                     sektor,
@@ -556,12 +569,12 @@ class BofInformation(ABC):
         ) -> tuple[list[dict[Any, Any]], list[dict[str, Any]]]:
             logger.debug("Args:\n" + f"foretaksnr: {foretaksnr}")
             if foretaksnr is not None:
-                conn = sqlite3.connect(SSB_BEDRIFT_PATH)
-                df = pd.read_sql_query(
-                    f"""SELECT bedrifts_nr, orgnr, navn, sn07_1, org_form, sysselsatte, ansatte_totalt, omsetning, statuskode, sb_type, statuskode_gdato, statuskode_rdato
-                    FROM ssb_bedrift WHERE foretaks_nr = '{foretaksnr}';""",
-                    conn,
-                )
+                with sqlite3.connect(SSB_BEDRIFT_PATH) as conn:
+                    df = pd.read_sql_query(
+                        f"""SELECT bedrifts_nr, orgnr, navn, sn07_1, sn2025_1, org_form, sysselsatte, ansatte_totalt, omsetning, statuskode, sb_type, statuskode_gdato, statuskode_rdato
+                        FROM ssb_bedrift WHERE foretaks_nr = '{foretaksnr}';""",
+                        conn,
+                    )
 
                 # Extract bedrift if it exists
                 bedrift = bedrift_or_dummy if has_bedrift else None

--- a/src/ssb_dash_framework/modules/bofregistry.py
+++ b/src/ssb_dash_framework/modules/bofregistry.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 SSB_FORETAK_PATH = "/buckets/shared/vof/oracle-hns/ssb_foretak.db"
 SSB_BEDRIFT_PATH = "/buckets/shared/vof/oracle-hns/ssb_bedrift.db"
 
+
 def ssb_foretak_modal() -> dbc.Modal:
     """Create a modal for displaying bof data.
 
@@ -434,7 +435,7 @@ class BofInformation(ABC):
             if n_clicks is None:
                 logger.debug("Raised PreventUpdate")
                 raise PreventUpdate
-                
+
             with sqlite3.connect(SSB_FORETAK_PATH) as conn:
                 df = pd.read_sql_query(
                     f"SELECT * FROM ssb_foretak WHERE orgnr = '{orgnr}'", conn
@@ -470,14 +471,14 @@ class BofInformation(ABC):
             if n_clicks is None or not selected_row:
                 logger.debug("Raised PreventUpdate")
                 alert_store = [
-                            create_alert(
-                                "Velg en bedrift fra bedriftslisten under for å hente BoF bedriftsinfo.",
-                                "info",
-                                position="center",
-                                duration=6,
-                                ephemeral=True,
-                            ),
-                            *alert_store,
+                    create_alert(
+                        "Velg en bedrift fra bedriftslisten under for å hente BoF bedriftsinfo.",
+                        "info",
+                        position="center",
+                        duration=6,
+                        ephemeral=True,
+                    ),
+                    *alert_store,
                 ]
                 return [], [], alert_store
 

--- a/src/ssb_dash_framework/modules/bofregistry.py
+++ b/src/ssb_dash_framework/modules/bofregistry.py
@@ -18,6 +18,7 @@ from sqlalchemy.util.typing import NoneType
 from ..setup.variableselector import VariableSelector
 from ..utils import TabImplementation
 from ..utils import WindowImplementation
+from ..utils import create_alert
 from ..utils.module_validation import module_validator
 
 logger = logging.getLogger(__name__)
@@ -452,19 +453,33 @@ class BofInformation(ABC):
         @callback(  # type: ignore[misc]
             Output("bofregistry-ssb_bedrift-table", "rowData"),
             Output("bofregistry-ssb_bedrift-table", "columnDefs"),
+            Output("alert_store", "data", allow_duplicate=True),
             Input("tab-vof-foretak-button2", "n_clicks"),
             State("tab-bof_foretak-table1", "selectedRows"),
+            State("alert_store", "data"),
+            prevent_initial_call=True,
         )
         def ssb_bof_bedrift(
             n_clicks: int | None,
             selected_row: list[dict[str, Any]],
-        ) -> tuple[list[dict[Any, Any]], list[dict[str, Any]]]:
+            alert_store: list[dict[str, Any]],
+        ) -> tuple[list[dict[Any, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
             logger.debug(
                 "Args:\n" + f"n_clicks: {n_clicks}\n" + f"selected_row: {selected_row}"
             )
             if n_clicks is None or not selected_row:
                 logger.debug("Raised PreventUpdate")
-                raise PreventUpdate
+                alert_store = [
+                            create_alert(
+                                "Velg en bedrift fra bedriftslisten under for å hente BoF bedriftsinfo.",
+                                "info",
+                                position="center",
+                                duration=6,
+                                ephemeral=True,
+                            ),
+                            *alert_store,
+                ]
+                return [], [], alert_store
 
             orgnr = selected_row[0]["orgnr"]
             with sqlite3.connect(SSB_BEDRIFT_PATH) as conn:
@@ -480,7 +495,7 @@ class BofInformation(ABC):
                 }
                 for col in df.columns
             ]
-            return df.to_dict("records"), columns
+            return df.to_dict("records"), columns, []
 
         @callback(  # type: ignore[misc]
             Output("tab-bof_foretak-orgnrcard", "value"),

--- a/src/ssb_dash_framework/setup/app_setup.py
+++ b/src/ssb_dash_framework/setup/app_setup.py
@@ -92,7 +92,7 @@ def app_setup(
         requests_pathname_prefix=(
             f"{service_prefix}proxy/{port}/" if service_prefix else None
         ),
-        external_stylesheets=[theme_map[stylesheet], dbc_css],
+        external_stylesheets=[theme_map[stylesheet], dbc_css, dbc.icons.BOOTSTRAP],
         assets_folder="../assets",
     )
 

--- a/src/ssb_dash_framework/utils/alert_handler.py
+++ b/src/ssb_dash_framework/utils/alert_handler.py
@@ -18,24 +18,42 @@ from ..utils.functions import sidebar_button
 logger = logging.getLogger(__name__)
 
 
+_DEFAULT_ICONS = {
+    "success": "bi bi-check-circle-fill",
+    "danger": "bi bi-x-circle-fill",
+    "warning": "bi bi-exclamation-triangle-fill",
+    "info": "bi bi-info-circle-fill",
+    "primary": "bi bi-bell-fill",
+    "secondary": "bi bi-bell-fill",
+    "light": "bi bi-bell-fill",
+    "dark": "bi bi-bell-fill",
+}
+
+
 def create_alert(
-    message: str, color: str | None = "info", ephemeral: bool | None = False
+    message: str, color: str | None = "info", ephemeral: bool | None = False, position: str | None = "bottom-left", duration: int | None = 5, icon: str | None = None,
 ) -> dict[str, Any]:
     """Creates a standardized alert record.
 
     Args:
         message: The alert message to display.
         color: The color of the alert, typically 'info', 'warning', or 'danger'. Defaults to 'info'.
-        ephemeral: If True, the alert appears at the top-center for 4 seconds but remains in the store for the modal. Defaults to False.
+        ephemeral: If True, the alert appears for 5 seconds but remains in the store for the modal. Defaults to False.
+        position: Controls alert placement ("bottom-left", "center", "top-right", etc.).
+        duration: Decides for how long the alert should show in seconds. Defaults to 5.
+        icon: Defines the alert icon on the notification. Defaults to the icons listed in _DEFAULT_ICONS according to color.
 
     Returns:
-        A dictionary containing the alert details, including timestamp, message, color, and ephemeral status.
+        A dictionary containing the alert details, including timestamp, message, color, ephemeral status, and alert position.
     """
     return {
         "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "message": message,
         "color": color,
         "ephemeral": ephemeral,
+        "position": position,
+        "duration": duration,
+        "icon": icon or _DEFAULT_ICONS.get(color),
         # used to track how long it's been visible if ephemeral
         "created_at": time.time(),
     }
@@ -46,7 +64,7 @@ class AlertHandler:
 
     This class provides functionality for:
     - Displaying a modal with all alerts, which can be filtered and dismissed.
-    - Showing ephemeral alerts at the top-middle of the screen for 4 seconds without removing them from the store.
+    - Showing ephemeral alerts at the top-middle of the screen for 5 seconds without removing them from the store.
 
     In order to add alerts to the AlertHandler, you need to modify your callback to include an extra State and Output and append your alert to the list of existing alerts.
 
@@ -92,10 +110,9 @@ class AlertHandler:
                     id="alert_store", data=[create_alert("Application started", "info")]
                 ),
                 dcc.Store(id="alert_filter", data="all"),
-                html.Div(
-                    id="alert_ephemeral_container",
-                    className="alert-container",
-                ),
+                html.Div(id="alert-container-bottom-left", className="alert-container bottom-left"),
+                html.Div(id="alert-container-center", className="alert-container center"),
+                html.Div(id="alert-container-top-right", className="alert-container top-right"),
                 dcc.Interval(
                     id="alert_ephemeral_interval", interval=1000, n_intervals=0
                 ),  # Unsure of performance, check if maybe it should update less often.
@@ -115,6 +132,12 @@ class AlertHandler:
                                         dbc.Col(
                                             dbc.Button(
                                                 "Vis kun info", id="alert_filter_info"
+                                            ),
+                                            width="auto",
+                                        ),
+                                        dbc.Col(
+                                            dbc.Button(
+                                                "Vis kun editeringer", id="alert_filter_success"
                                             ),
                                             width="auto",
                                         ),
@@ -184,20 +207,22 @@ class AlertHandler:
             Output("alert_filter", "data"),
             Input("alert_filter_all", "n_clicks"),
             Input("alert_filter_info", "n_clicks"),
+            Input("alert_filter_success", "n_clicks"),
             Input("alert_filter_warning", "n_clicks"),
             Input("alert_filter_danger", "n_clicks"),
             prevent_initial_call=True,
         )
         def set_filter(
-            _: int | None, __: int | None, ___: int | None, ____: int | None
+            _: int | None, __: int | None, ___: int | None, ____: int | None, _____: int | None
         ) -> str:
             """Updates the alert filter based on the clicked filter button.
 
             Args:
                 _: Number of clicks on the "Vis alle" button.
                 __: Number of clicks on the "Vis kun info" button.
-                ___: Number of clicks on the "Vis kun advarsel" button.
-                ____: Number of clicks on the "Vis kun feil" button.
+                ___: Number of clicks on the "Vis kun editeringer" button.
+                ____: Number of clicks on the "Vis kun advarsel" button.
+                _____: Number of clicks on the "Vis kun feil" button.
 
             Returns:
                 str: The selected filter type ('all', 'info', 'warning', or 'danger').
@@ -205,6 +230,8 @@ class AlertHandler:
             triggered_id = ctx.triggered_id if hasattr(ctx, "triggered_id") else None
             if triggered_id == "alert_filter_info":
                 return "info"
+            elif triggered_id == "alert_filter_success":
+                return "success"
             elif triggered_id == "alert_filter_warning":
                 return "warning"
             elif triggered_id == "alert_filter_danger":
@@ -239,19 +266,24 @@ class AlertHandler:
 
             components = []
             for i, alert_data in enumerate(alerts):
+                icon = html.I(className=f"{alert_data['icon']} me-3 alert-icon") if alert_data.get("icon") else None
                 components.append(
                     dbc.Alert(
                         [
-                            html.Span(
-                                alert_data["timestamp"] + " ", className="text-muted"
-                            ),
-                            alert_data["message"],
+                            html.Div(
+                                [
+                                    icon,
+                                    html.Small(alert_data["timestamp"], className="alert-timestamp me-3"),
+                                    dcc.Markdown(alert_data["message"], className="alert-message", style={"display": "inline-block"}),
+                                ],
+                                className="d-flex align-items-center",
+                            ), 
                         ],
                         color=alert_data["color"],
                         dismissable=True,
                         is_open=True,
                         id={"type": "modal_alert", "index": i},
-                        className="mb-2",
+                        className="mb-2 alert-modal-item",
                     )
                 )
             return components
@@ -260,10 +292,11 @@ class AlertHandler:
             Output("alert_store", "data", allow_duplicate=True),
             Input({"type": "modal_alert", "index": ALL}, "is_open"),
             State("alert_store", "data"),
+            State("alert_filter", "data"),
             prevent_initial_call=True,
         )
         def remove_dismissed_alerts(
-            is_open_list: list[dbc.Alert], current_alerts: list[dict[str, Any]]
+            is_open_list: list[dbc.Alert], current_alerts: list[dict[str, Any]], current_filter
         ) -> list[dict[str, Any]]:
             """Removes alerts that have been dismissed by the user.
 
@@ -279,29 +312,33 @@ class AlertHandler:
             if not current_alerts or not is_open_list:
                 return current_alerts
 
-            new_list = []
-            display_index = 0
-            for alert_item in current_alerts:
-                if display_index < len(is_open_list):
-                    if is_open_list[display_index]:  # still open => keep
-                        new_list.append(alert_item)
-                    display_index += 1
-                else:
-                    new_list.append(alert_item)
+            # Reproduce the same filtered view the modal used
+            filtered = [
+            (i, a) for i, a in enumerate(current_alerts)
+                if current_filter == "all" or a["color"] == current_filter
+            ]
 
-            return new_list
+            to_remove = set()
+            for display_index, (original_index, _) in enumerate(filtered):
+                if display_index < len(is_open_list) and not is_open_list[display_index]:
+                    to_remove.add(original_index)
+
+            return [a for i, a in enumerate(current_alerts) if i not in to_remove]
 
         @callback(  # type: ignore[misc]
-            Output("alert_ephemeral_container", "children"),
+            Output("alert-container-bottom-left", "children"),
+            Output("alert-container-center", "children"),
+            Output("alert-container-top-right", "children"),
             Input("alert_ephemeral_interval", "n_intervals"),
             State("alert_store", "data"),
         )
         def display_ephemeral_alerts(
             _: int, alerts: list[dict[str, Any]]
-        ) -> list[dict[str, Any]]:
-            """Displays ephemeral alerts for 4 seconds.
+        ) -> tuple[list, list, list]:
+            """Displays ephemeral alerts for 5 seconds.
 
             Ephemeral alerts are not removed from the store, so they remain visible in the modal.
+            Determines the location of the alert based on the input, where default is "bottom-left".
 
             Args:
                 _: The number of intervals elapsed since the application started.
@@ -311,25 +348,37 @@ class AlertHandler:
                 A list of Dash Bootstrap Components alerts to display as ephemeral alerts.
             """  # noqa: DOC102, DOC103
             if not alerts:
-                return []
+                return [], [], []
 
             now = time.time()
             ephemeral_alerts = [
                 a
                 for a in alerts
-                if a.get("ephemeral", False) and (now - a["created_at"] < 4)
+                if a.get("ephemeral", False) and (now - a["created_at"] < a.get("duration", 5))
             ]
 
-            comps = []
-            for a in ephemeral_alerts:
-                comps.append(
-                    dbc.Alert(
-                        [
-                            html.Small(a["timestamp"] + ": ", className="text-muted"),
-                            a["message"],
-                        ],
-                        color=a["color"],
-                        className="mb-2",
-                    )
+            def make_alert(a):
+                now = time.time()
+                dying = (now - a["created_at"]) > (a.get("duration", 6) - 0.8)
+                icon = html.I(className=f"{a['icon']} me-2 alert-icon") if a.get("icon") else None
+
+                return dbc.Alert(
+                    [
+                        html.Div(
+                            [
+                                icon,
+                                dcc.Markdown(a["message"], className="alert-message"),
+                            ],
+                            className="d-flex align-items-center",
+                        ),
+                        # html.Small(a["timestamp"], className="alert-timestamp"),
+                    ],
+                    color=a["color"],
+                    className=f"mb-2 alert-toast {'alert-dying' if dying else ''}",
                 )
-            return comps
+
+            bottom_left = [make_alert(a) for a in ephemeral_alerts if a.get("position", "bottom-left") == "bottom-left"]
+            center      = [make_alert(a) for a in ephemeral_alerts if a.get("position") == "center"]
+            top_right   = [make_alert(a) for a in ephemeral_alerts if a.get("position") == "top-right"]
+
+            return bottom_left, center, top_right

--- a/src/ssb_dash_framework/utils/alert_handler.py
+++ b/src/ssb_dash_framework/utils/alert_handler.py
@@ -31,7 +31,12 @@ _DEFAULT_ICONS = {
 
 
 def create_alert(
-    message: str, color: str | None = "info", ephemeral: bool | None = False, position: str | None = "bottom-left", duration: int | None = 5, icon: str | None = None,
+    message: str,
+    color: str | None = "info",
+    ephemeral: bool | None = False,
+    position: str | None = "bottom-left",
+    duration: int | None = 5,
+    icon: str | None = None,
 ) -> dict[str, Any]:
     """Creates a standardized alert record.
 
@@ -110,9 +115,17 @@ class AlertHandler:
                     id="alert_store", data=[create_alert("Application started", "info")]
                 ),
                 dcc.Store(id="alert_filter", data="all"),
-                html.Div(id="alert-container-bottom-left", className="alert-container bottom-left"),
-                html.Div(id="alert-container-center", className="alert-container center"),
-                html.Div(id="alert-container-top-right", className="alert-container top-right"),
+                html.Div(
+                    id="alert-container-bottom-left",
+                    className="alert-container bottom-left",
+                ),
+                html.Div(
+                    id="alert-container-center", className="alert-container center"
+                ),
+                html.Div(
+                    id="alert-container-top-right",
+                    className="alert-container top-right",
+                ),
                 dcc.Interval(
                     id="alert_ephemeral_interval", interval=1000, n_intervals=0
                 ),  # Unsure of performance, check if maybe it should update less often.
@@ -137,7 +150,8 @@ class AlertHandler:
                                         ),
                                         dbc.Col(
                                             dbc.Button(
-                                                "Vis kun editeringer", id="alert_filter_success"
+                                                "Vis kun editeringer",
+                                                id="alert_filter_success",
                                             ),
                                             width="auto",
                                         ),
@@ -213,7 +227,11 @@ class AlertHandler:
             prevent_initial_call=True,
         )
         def set_filter(
-            _: int | None, __: int | None, ___: int | None, ____: int | None, _____: int | None
+            _: int | None,
+            __: int | None,
+            ___: int | None,
+            ____: int | None,
+            _____: int | None,
         ) -> str:
             """Updates the alert filter based on the clicked filter button.
 
@@ -266,18 +284,29 @@ class AlertHandler:
 
             components = []
             for i, alert_data in enumerate(alerts):
-                icon = html.I(className=f"{alert_data['icon']} me-3 alert-icon") if alert_data.get("icon") else None
+                icon = (
+                    html.I(className=f"{alert_data['icon']} me-3 alert-icon")
+                    if alert_data.get("icon")
+                    else None
+                )
                 components.append(
                     dbc.Alert(
                         [
                             html.Div(
                                 [
                                     icon,
-                                    html.Small(alert_data["timestamp"], className="alert-timestamp me-3"),
-                                    dcc.Markdown(alert_data["message"], className="alert-message", style={"display": "inline-block"}),
+                                    html.Small(
+                                        alert_data["timestamp"],
+                                        className="alert-timestamp me-3",
+                                    ),
+                                    dcc.Markdown(
+                                        alert_data["message"],
+                                        className="alert-message",
+                                        style={"display": "inline-block"},
+                                    ),
                                 ],
                                 className="d-flex align-items-center",
-                            ), 
+                            ),
                         ],
                         color=alert_data["color"],
                         dismissable=True,
@@ -296,7 +325,9 @@ class AlertHandler:
             prevent_initial_call=True,
         )
         def remove_dismissed_alerts(
-            is_open_list: list[dbc.Alert], current_alerts: list[dict[str, Any]], current_filter
+            is_open_list: list[dbc.Alert],
+            current_alerts: list[dict[str, Any]],
+            current_filter,
         ) -> list[dict[str, Any]]:
             """Removes alerts that have been dismissed by the user.
 
@@ -314,13 +345,17 @@ class AlertHandler:
 
             # Reproduce the same filtered view the modal used
             filtered = [
-            (i, a) for i, a in enumerate(current_alerts)
+                (i, a)
+                for i, a in enumerate(current_alerts)
                 if current_filter == "all" or a["color"] == current_filter
             ]
 
             to_remove = set()
             for display_index, (original_index, _) in enumerate(filtered):
-                if display_index < len(is_open_list) and not is_open_list[display_index]:
+                if (
+                    display_index < len(is_open_list)
+                    and not is_open_list[display_index]
+                ):
                     to_remove.add(original_index)
 
             return [a for i, a in enumerate(current_alerts) if i not in to_remove]
@@ -354,13 +389,18 @@ class AlertHandler:
             ephemeral_alerts = [
                 a
                 for a in alerts
-                if a.get("ephemeral", False) and (now - a["created_at"] < a.get("duration", 5))
+                if a.get("ephemeral", False)
+                and (now - a["created_at"] < a.get("duration", 5))
             ]
 
             def make_alert(a):
                 now = time.time()
                 dying = (now - a["created_at"]) > (a.get("duration", 6) - 0.8)
-                icon = html.I(className=f"{a['icon']} me-2 alert-icon") if a.get("icon") else None
+                icon = (
+                    html.I(className=f"{a['icon']} me-2 alert-icon")
+                    if a.get("icon")
+                    else None
+                )
 
                 return dbc.Alert(
                     [
@@ -377,8 +417,18 @@ class AlertHandler:
                     className=f"mb-2 alert-toast {'alert-dying' if dying else ''}",
                 )
 
-            bottom_left = [make_alert(a) for a in ephemeral_alerts if a.get("position", "bottom-left") == "bottom-left"]
-            center      = [make_alert(a) for a in ephemeral_alerts if a.get("position") == "center"]
-            top_right   = [make_alert(a) for a in ephemeral_alerts if a.get("position") == "top-right"]
+            bottom_left = [
+                make_alert(a)
+                for a in ephemeral_alerts
+                if a.get("position", "bottom-left") == "bottom-left"
+            ]
+            center = [
+                make_alert(a) for a in ephemeral_alerts if a.get("position") == "center"
+            ]
+            top_right = [
+                make_alert(a)
+                for a in ephemeral_alerts
+                if a.get("position") == "top-right"
+            ]
 
             return bottom_left, center, top_right

--- a/tests/test_alert_handler.py
+++ b/tests/test_alert_handler.py
@@ -7,7 +7,7 @@ from ssb_dash_framework.utils.alert_handler import create_alert
 def test_create_alert() -> None:
     alert = create_alert("Test message", "info", True)
     assert isinstance(alert, dict)
-    assert len(alert.keys()) == 5
+    assert len(alert.keys()) == 8
 
 
 def test_alerthandler() -> None:


### PR DESCRIPTION
- Updated bofregistry code to close conn after queries, and added nace 2007 and nace 2025 to foretak and bedrift
- Hid some columns in history table as they made the view too crowded
- Visual (added icons and fixed text/borders, slide-in and fade out animation) and backend changes to alert system, mainly new parameters that can be used such as duration, position and icon (if you want to use specific ones)
- Fixed altinn editor error alerts as these were missing when for instance editing cols you shouldn't be editing (ident, refnr, skjema and so on)