### PR TITLE
feat: right-click any AG Grid cell to copy value to clipboard

### DIFF
--- a/src/ssb_dash_framework/assets/dashAgGridFunctions.js
+++ b/src/ssb_dash_framework/assets/dashAgGridFunctions.js
@@ -6,7 +6,7 @@ window.dashAgGridFunctions = window.dashAgGridFunctions || {};
  * ----------------------------------------------------------------------- */
 (function () {
     function showCopyNotification(value) {
-        var container = document.getElementById('alert_ephemeral_container');
+        var container = document.getElementById('alert-container-bottom-left');
         if (!container) return;
         var now = new Date();
         var ts = now.getFullYear() + '-' +


### PR DESCRIPTION
## Summary

- Right-clicking any AG Grid cell now immediately copies the cell value
  to the clipboard and shows a "Kopiert: <value>" notification in the
  bottom-left corner, using the existing ephemeral alert system
- No Python changes required - implemented as a global JS listener in
  `ssb_dash_framework/assets/dashAgGridFunctions.js`

## Implementation notes

- Uses a capture-phase `contextmenu` listener so it fires before AG Grid
  can intercept the event
- Injects the notification directly into `#alert_ephemeral_container`
  to match the style and position of existing variable-update alerts
- Includes a `textarea` fallback for clipboard access over plain HTTP
- AG Grid Enterprise's `getContextMenuItems` API was considered but is
  not available in the community edition bundled with `dash-ag-grid`


## Popup fix:
This bug was found and fixed by: SarTorvFroeystad
