### PR TITLE
Macro module: add click-confirmation popup before opening foretak/bedrift

### DIFF
--- a/src/ssb_dash_framework/assets/dashAgGridFunctions.js
+++ b/src/ssb_dash_framework/assets/dashAgGridFunctions.js
@@ -273,6 +273,64 @@ window.dashAgGridFunctions.MacroModule = {
         return prefixB !== prefixF;
     },
 
+    // === Function showClickPopup (Show confirmation popup when a name/orgnr cell is clicked in the detail grid) ===
+    showClickPopup(cellClicked, rowData, orgnrFCol, orgnrBCol, namedCol) {
+        var noShow = [null, '', {display: 'none'}];
+        if (!cellClicked || !rowData) return noShow;
+
+        var colId = cellClicked.colId;
+        var rowId = cellClicked.rowId;
+        if (rowId == null || [orgnrFCol, orgnrBCol, namedCol].indexOf(colId) === -1) {
+            return noShow;
+        }
+
+        var rowIdx = parseInt(rowId);
+        if (isNaN(rowIdx) || rowIdx >= rowData.length) return noShow;
+
+        var row = rowData[rowIdx];
+        var navn = row[namedCol] || '';
+        var label;
+        if (colId === orgnrBCol) {
+            label = 'Bedrift: ' + navn + ' (' + (row[orgnrBCol] || '') + ')';
+        } else {
+            label = 'Foretak: ' + navn + ' (' + (row[orgnrFCol] || '') + ')';
+        }
+
+        var pendingData = {rowId: rowId, colId: colId, rowData: row};
+
+        // Position relative to the detail grid container so the popup
+        // scrolls with the page instead of floating over it.
+        var containerEl = document.querySelector('.macromodule-detail-grid-container');
+        var style;
+        if (containerEl) {
+            var rect = containerEl.getBoundingClientRect();
+            var relX = (window._macroModuleLastClickX || 0) - rect.left;
+            var relY = (window._macroModuleLastClickY || 0) - rect.top;
+            style = {
+                display: 'flex',
+                position: 'absolute',
+                top: (relY + 12) + 'px',
+                left: relX + 'px',
+                zIndex: '9999'
+            };
+        } else {
+            style = {
+                display: 'flex',
+                position: 'fixed',
+                top: ((window._macroModuleLastClickY || 0) + 12) + 'px',
+                left: (window._macroModuleLastClickX || 0) + 'px',
+                zIndex: '9999'
+            };
+        }
+        return [pendingData, label, style];
+    },
+
+    // === Function hidePopupOnClear (Hide the confirmation popup when pending data is cleared) ===
+    hidePopupOnClear(pendingData) {
+        if (!pendingData) return {display: 'none'};
+        return window.dash_clientside.no_update;
+    },
+
     // === Function displayDiffColumnHighlight (Mark tilgang & avgang on the diff-column) ===
     displayDiffColumnHighlight(props) {
         if (!props.data) return {};

--- a/src/ssb_dash_framework/assets/dashAgGridFunctions.js
+++ b/src/ssb_dash_framework/assets/dashAgGridFunctions.js
@@ -306,5 +306,10 @@ window.dashAgGridFunctions.MacroModule = {
 
         return {};
     }
-
 };
+
+// Track last mouse click position so the popup can be anchored to the clicked cell
+document.addEventListener('click', function(e) {
+    window._macroModuleLastClickX = e.clientX;
+    window._macroModuleLastClickY = e.clientY;
+});

--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -462,6 +462,7 @@ MacroModule
 .macromodule-detail-grid-container {
     margin-top: 20px;
     height: 750px;
+    position: relative;
 }
 
 .macromodule-detail-grid-container h5 {
@@ -471,6 +472,43 @@ MacroModule
 /* Row styling */
 .macromodule-naring-mismatch {
     opacity: 0.5 !important;
+}
+
+/* Detail grid click-confirmation popup */
+.macromodule-click-popup {
+    align-items: center;
+    gap: 10px;
+    background: #ffffff;
+    border: 1px solid #b0b0b0;
+    border-radius: 5px;
+    padding: 7px 12px;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.18);
+    white-space: nowrap;
+    pointer-events: auto;
+}
+
+.macromodule-click-popup-label {
+    color: #333;
+    font-size: 13px;
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.macromodule-bruk-button {
+    background-color: #1a4d7e;
+    color: #ffffff;
+    border: none;
+    padding: 5px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: bold;
+    flex-shrink: 0;
+}
+
+.macromodule-bruk-button:hover {
+    background-color: #255f9a;
 }
 
 /*

--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -496,19 +496,15 @@ MacroModule
 }
 
 .macromodule-bruk-button {
-    background-color: #1a4d7e;
-    color: #ffffff;
-    border: none;
+    color: #2c2c2c !important;
+    background-color: #d4d4d4 !important;
+    border-color: #000 !important;
     padding: 5px 16px;
     border-radius: 4px;
     cursor: pointer;
     font-size: 13px;
     font-weight: bold;
     flex-shrink: 0;
-}
-
-.macromodule-bruk-button:hover {
-    background-color: #255f9a;
 }
 
 /*

--- a/src/ssb_dash_framework/modules/macro_module.py
+++ b/src/ssb_dash_framework/modules/macro_module.py
@@ -14,6 +14,7 @@ from dash import Input
 from dash import Output
 from dash import State
 from dash import callback
+from dash import clientside_callback
 from dash import dcc
 from dash import html
 from dash.exceptions import PreventUpdate
@@ -509,8 +510,28 @@ class MacroModule:
                                 )
                             ],
                         ),
+                        # Confirmation popup — absolute-positioned inside this container
+                        # so it scrolls with the page rather than floating over it.
+                        html.Div(
+                            id="macromodule-click-popup",
+                            className="macromodule-click-popup",
+                            style={"display": "none"},
+                            children=[
+                                html.Span(
+                                    id="macromodule-click-popup-label",
+                                    className="macromodule-click-popup-label",
+                                ),
+                                html.Button(
+                                    "Bruk",
+                                    id="macromodule-bruk-button",
+                                    className="macromodule-bruk-button",
+                                    n_clicks=0,
+                                ),
+                            ],
+                        ),
                     ],
                 ),
+                dcc.Store(id="macromodule-pending-click-store"),
             ],
         )
         logger.debug("Layout generated.")
@@ -1283,6 +1304,7 @@ class MacroModule:
             Output("macromodule-detail-grid", "rowData", allow_duplicate=True),
             Output("macromodule-detail-grid", "columnDefs", allow_duplicate=True),
             Output("macromodule-detail-grid-title", "children", allow_duplicate=True),
+            Output("macromodule-pending-click-store", "data", allow_duplicate=True),
             Input("var-aar", "value"),
             Input("macromodule-foretak-or-bedrift", "value"),
             Input("macromodule-filter-velger", "value"),
@@ -1291,9 +1313,9 @@ class MacroModule:
             Input("macromodule-macro-variable", "value"),
             prevent_initial_call=True,
         )
-        def reset_detail_grid_on_filter_change(*args: Any) -> tuple[list, list, str]:
-            """Reset detail grid when any filter changes."""
-            return [], [], ""
+        def reset_detail_grid_on_filter_change(*args: Any) -> tuple[list, list, str, None]:
+            """Reset detail grid and dismiss popup when any filter changes."""
+            return [], [], "", None
 
         @callback(
             Output("macromodule-macro-variable", "disabled"),
@@ -1303,32 +1325,96 @@ class MacroModule:
             """Disables macro-variable if sammensatte variabler is selected by user."""
             return macro_level == "sammensatte variabler"
 
+        clientside_callback(
+            """
+            function(cellClicked, rowData) {
+                var noShow = [null, '', {display: 'none'}];
+                if (!cellClicked || !rowData) return noShow;
+
+                var colId = cellClicked.colId;
+                var rowId = cellClicked.rowId;
+                if (rowId == null || ['orgnr_f', 'orgnr_b', 'navn'].indexOf(colId) === -1) {
+                    return noShow;
+                }
+
+                var rowIdx = parseInt(rowId);
+                if (isNaN(rowIdx) || rowIdx >= rowData.length) return noShow;
+
+                var row = rowData[rowIdx];
+                var navn = row.navn || '';
+                var label;
+                if (colId === 'orgnr_b') {
+                    label = 'Bedrift: ' + navn + ' (' + (row.orgnr_b || '') + ')';
+                } else {
+                    label = 'Foretak: ' + navn + ' (' + (row.orgnr_f || '') + ')';
+                }
+
+                var pendingData = {rowId: rowId, colId: colId, rowData: row};
+
+                // Position relative to the detail grid container so the popup
+                // scrolls with the page instead of floating over it.
+                var containerEl = document.querySelector('.macromodule-detail-grid-container');
+                var style;
+                if (containerEl) {
+                    var rect = containerEl.getBoundingClientRect();
+                    var relX = (window._macroModuleLastClickX || 0) - rect.left;
+                    var relY = (window._macroModuleLastClickY || 0) - rect.top;
+                    style = {
+                        display: 'flex',
+                        position: 'absolute',
+                        top: (relY + 12) + 'px',
+                        left: relX + 'px',
+                        zIndex: '9999'
+                    };
+                } else {
+                    style = {
+                        display: 'flex',
+                        position: 'fixed',
+                        top: ((window._macroModuleLastClickY || 0) + 12) + 'px',
+                        left: (window._macroModuleLastClickX || 0) + 'px',
+                        zIndex: '9999'
+                    };
+                }
+                return [pendingData, label, style];
+            }
+            """,
+            Output("macromodule-pending-click-store", "data"),
+            Output("macromodule-click-popup-label", "children"),
+            Output("macromodule-click-popup", "style"),
+            Input("macromodule-detail-grid", "cellClicked"),
+            State("macromodule-detail-grid", "rowData"),
+        )
+
+        clientside_callback(
+            """
+            function(pendingData) {
+                if (!pendingData) return {display: 'none'};
+                return window.dash_clientside.no_update;
+            }
+            """,
+            Output("macromodule-click-popup", "style", allow_duplicate=True),
+            Input("macromodule-pending-click-store", "data"),
+            prevent_initial_call=True,
+        )
+
         @callback(  # type: ignore[misc]
             Output("var-ident", "value", allow_duplicate=True),
             Output("var-bedrift", "value", allow_duplicate=True),
             Output("altinnedit-option1", "value", allow_duplicate=True),
-            Input("macromodule-detail-grid", "cellClicked"),
-            State("macromodule-detail-grid", "rowData"),
+            Output("macromodule-pending-click-store", "data", allow_duplicate=True),
+            Input("macromodule-bruk-button", "n_clicks"),
+            State("macromodule-pending-click-store", "data"),
             prevent_initial_call=True,
         )
         def output_to_variabelvelger(
-            clickdata: dict | None, rowdata: list[dict[str, Any]]
-        ) -> tuple[str, str, str]:
-            """Handle cell clicks in detail grid and update variable selector in the Dash app."""
-            if not clickdata:
+            n_clicks: int | None, pending_data: dict | None
+        ) -> tuple[str, str, str, None]:
+            """Apply pending cell selection to variable selector when user clicks Bruk."""
+            if not n_clicks or not pending_data:
                 raise PreventUpdate
 
-            row_id = clickdata.get("rowId")
-            col_id = clickdata.get("colId")
-
-            if row_id is None or col_id not in ("orgnr_f", "orgnr_b", "navn"):
-                raise PreventUpdate
-
-            row_idx = int(row_id)
-            if row_idx >= len(rowdata):
-                raise PreventUpdate
-
-            clicked_row = rowdata[row_idx]
+            col_id = pending_data.get("colId")
+            clicked_row = pending_data.get("rowData", {})
             bedrift = ""
 
             if col_id in ("orgnr_f", "navn"):
@@ -1345,6 +1431,7 @@ class MacroModule:
                 str(ident) if ident else "",
                 str(bedrift) if bedrift else "",
                 str(tabell) if tabell else "",
+                None,
             )
 
 

--- a/src/ssb_dash_framework/modules/macro_module.py
+++ b/src/ssb_dash_framework/modules/macro_module.py
@@ -522,7 +522,7 @@ class MacroModule:
                                     className="macromodule-click-popup-label",
                                 ),
                                 html.Button(
-                                    "Bruk",
+                                    "Velg",
                                     id="macromodule-bruk-button",
                                     className="macromodule-bruk-button",
                                     n_clicks=0,
@@ -1328,54 +1328,9 @@ class MacroModule:
         clientside_callback(
             """
             function(cellClicked, rowData) {
-                var noShow = [null, '', {display: 'none'}];
-                if (!cellClicked || !rowData) return noShow;
-
-                var colId = cellClicked.colId;
-                var rowId = cellClicked.rowId;
-                if (rowId == null || ['orgnr_f', 'orgnr_b', 'navn'].indexOf(colId) === -1) {
-                    return noShow;
-                }
-
-                var rowIdx = parseInt(rowId);
-                if (isNaN(rowIdx) || rowIdx >= rowData.length) return noShow;
-
-                var row = rowData[rowIdx];
-                var navn = row.navn || '';
-                var label;
-                if (colId === 'orgnr_b') {
-                    label = 'Bedrift: ' + navn + ' (' + (row.orgnr_b || '') + ')';
-                } else {
-                    label = 'Foretak: ' + navn + ' (' + (row.orgnr_f || '') + ')';
-                }
-
-                var pendingData = {rowId: rowId, colId: colId, rowData: row};
-
-                // Position relative to the detail grid container so the popup
-                // scrolls with the page instead of floating over it.
-                var containerEl = document.querySelector('.macromodule-detail-grid-container');
-                var style;
-                if (containerEl) {
-                    var rect = containerEl.getBoundingClientRect();
-                    var relX = (window._macroModuleLastClickX || 0) - rect.left;
-                    var relY = (window._macroModuleLastClickY || 0) - rect.top;
-                    style = {
-                        display: 'flex',
-                        position: 'absolute',
-                        top: (relY + 12) + 'px',
-                        left: relX + 'px',
-                        zIndex: '9999'
-                    };
-                } else {
-                    style = {
-                        display: 'flex',
-                        position: 'fixed',
-                        top: ((window._macroModuleLastClickY || 0) + 12) + 'px',
-                        left: (window._macroModuleLastClickX || 0) + 'px',
-                        zIndex: '9999'
-                    };
-                }
-                return [pendingData, label, style];
+                return window.dashAgGridFunctions.MacroModule.showClickPopup(
+                    cellClicked, rowData, 'orgnr_f', 'orgnr_b', 'navn'
+                );
             }
             """,
             Output("macromodule-pending-click-store", "data"),
@@ -1386,12 +1341,7 @@ class MacroModule:
         )
 
         clientside_callback(
-            """
-            function(pendingData) {
-                if (!pendingData) return {display: 'none'};
-                return window.dash_clientside.no_update;
-            }
-            """,
+            "window.dashAgGridFunctions.MacroModule.hidePopupOnClear",
             Output("macromodule-click-popup", "style", allow_duplicate=True),
             Input("macromodule-pending-click-store", "data"),
             prevent_initial_call=True,


### PR DESCRIPTION
## Why

Clicking a cell in the detail grid (navn, orgnr_f, orgnr_b columns) immediately
triggers a slow data load in "vis variabler". Users frequently misclick, forcing
them to navigate back and reload. This PR adds a lightweight confirmation step so
accidental clicks have no cost.

## What was changed and where

### `modules/macro_module.py`
- **Layout**: added a `dcc.Store` (`macromodule-pending-click-store`) and a floating
  confirmation popup (`macromodule-click-popup`) with a label and a **Bruk** button.
  The popup lives *inside* `.macromodule-detail-grid-container` so it scrolls with
  the page rather than floating over it.
- **`output_to_variabelvelger`** (renamed behaviour, not function): changed the
  trigger from `cellClicked` → `macromodule-bruk-button.n_clicks`. The callback now
  reads the pending row from the store instead of from `rowData` directly, and resets
  the store to `None` on apply (which hides the popup).
- **New clientside callback** (replaces the old server-side `store_pending_click`):
  fires immediately in the browser on `cellClicked`, validates the column, builds the
  label text, and positions the popup - no server round-trip, so the popup is instant.
- **Second clientside callback**: watches the store; hides the popup whenever the
  store is reset to `None` (after Bruk is clicked or a filter changes).
- **`reset_detail_grid_on_filter_change`**: extended to also reset the pending click
  store, dismissing the popup when the user changes year, næring, filter, etc.

### `assets/dashAgGridFunctions.js`
- Added a global `click` event listener that saves `clientX/Y` to
  `window._macroModuleLastClickX/Y`. The clientside callback reads these to anchor
  the popup to the exact spot where the user clicked.

### `assets/stylesheet.css`
- Added `position: relative` to `.macromodule-detail-grid-container` so the
  `position: absolute` popup resolves its coordinates against the container (and
  therefore scrolls with the page).
- Added styles for `.macromodule-click-popup`, `.macromodule-click-popup-label`, and
  `.macromodule-bruk-button`.

## Behaviour summary

| Action | Result |
|---|---|
| Click navn / orgnr_f / orgnr_b | Popup appears instantly at click position |
| Click another valid cell | Popup moves and updates to the new entity |
| Click a non-clickable column | Popup disappears |
| Click **Bruk** | Selection applied to "vis variabler", popup closes |
| Change any filter | Popup dismissed automatically |
