### PR TITLE
Microlayout callback fixes

### DIFF
--- a/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_custom.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_custom.py
@@ -305,6 +305,7 @@ class DataViewCustom(DataEditorDataView):
                         "form_data_field_name_column"
                     ),
                 )
+                print(f"Built microlayout:\n{microlayout}")
                 components.append(microlayout)
             else:
                 components.extend(self.build_layout(value))
@@ -323,23 +324,36 @@ class DataViewCustom(DataEditorDataView):
         pass
 
     @classmethod
-    def convert_typed_to_keyed(cls, node):
+    def convert_typed_to_keyed(
+        cls, node, applies_to_tables=None, applies_to_forms=None
+    ):
+        print(f"inputs: {node}, {applies_to_tables}, {applies_to_forms}")
         if isinstance(node, list):
-            return [cls.convert_typed_to_keyed(item) for item in node]
+            return [
+                cls.convert_typed_to_keyed(item, applies_to_tables, applies_to_forms)
+                for item in node
+            ]
 
         if isinstance(node, dict):
             if node.get("type") == "microlayout":
                 inner = {k: v for k, v in node.items() if k != "type"}
                 if "layout" in inner:
                     inner["layout"] = [
-                        convert_node(child)
-                        for child in cls.convert_typed_to_keyed(inner["layout"])
+                        convert_node(child, applies_to_tables, applies_to_forms)
+                        for child in cls.convert_typed_to_keyed(
+                            inner["layout"], applies_to_tables, applies_to_forms
+                        )
                     ]
                 if "children" in inner:
-                    inner["children"] = cls.convert_typed_to_keyed(inner["children"])
+                    inner["children"] = cls.convert_typed_to_keyed(
+                        inner["children"], applies_to_tables, applies_to_forms
+                    )
                 return {"microlayout": inner}
 
-            return {k: cls.convert_typed_to_keyed(v) for k, v in node.items()}
+            return {
+                k: cls.convert_typed_to_keyed(v, applies_to_tables, applies_to_forms)
+                for k, v in node.items()
+            }
 
         return node
 
@@ -354,7 +368,11 @@ class DataViewCustom(DataEditorDataView):
         if isinstance(config, list):
             config = config[0]
 
-        config["layout"] = cls.convert_typed_to_keyed(config["layout"])
+        config["layout"] = cls.convert_typed_to_keyed(
+            config["layout"],
+            applies_to_tables=config["applies_to_tables"],
+            applies_to_forms=config["applies_to_forms"],
+        )
 
         return cls(
             applies_to_tables=config["applies_to_tables"],
@@ -402,15 +420,31 @@ class DataViewCustom(DataEditorDataView):
         return lines
 
 
-def convert_node(node: dict) -> dict:
+def convert_node_build_field_settings(node, attribute, value):
+    logger.debug(f"node: {node}\nattribute: {attribute}\nvalue: {value}")
+    if "field_settings" not in node:
+        node["field_settings"] = {}
+    node["field_settings"].update({attribute: value})
+    logger.debug(node, attribute, value)
+    return node
 
-    if "label" in node:
-        node["label"] = node["label"]
 
+def convert_node(node: dict, applies_to_tables=None, applies_to_forms=None) -> dict:
+    print(f"node: {node}\ntables: {applies_to_tables}\nforms: {applies_to_forms}")
+    if applies_to_tables is None:
+        applies_to_tables = []
+    if applies_to_forms is None:
+        applies_to_forms = []
     if "variable" in node:
-        node["field_settings"] = {"field_path": node["variable"]}
+        node = convert_node_build_field_settings(node, "field_path", node["variable"])
+        node = convert_node_build_field_settings(
+            node, "applies_to_tables", applies_to_tables
+        )
+        node = convert_node_build_field_settings(
+            node, "applies_to_forms", applies_to_forms
+        )
 
     if "children" in node:
-        node["children"] = [convert_node(child) for child in node["children"]]
+        node["children"] = [convert_node(child, applies_to_tables=applies_to_tables, applies_to_forms=applies_to_forms) for child in node["children"]]
 
     return node

--- a/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_custom.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_custom.py
@@ -305,7 +305,7 @@ class DataViewCustom(DataEditorDataView):
                         "form_data_field_name_column"
                     ),
                 )
-                print(f"Built microlayout:\n{microlayout}")
+                logger.debug(f"Built microlayout:\n{microlayout}")
                 components.append(microlayout)
             else:
                 components.extend(self.build_layout(value))
@@ -327,7 +327,7 @@ class DataViewCustom(DataEditorDataView):
     def convert_typed_to_keyed(
         cls, node, applies_to_tables=None, applies_to_forms=None
     ):
-        print(f"inputs: {node}, {applies_to_tables}, {applies_to_forms}")
+        logger.debug(f"inputs: {node}, {applies_to_tables}, {applies_to_forms}")
         if isinstance(node, list):
             return [
                 cls.convert_typed_to_keyed(item, applies_to_tables, applies_to_forms)
@@ -430,7 +430,9 @@ def convert_node_build_field_settings(node, attribute, value):
 
 
 def convert_node(node: dict, applies_to_tables=None, applies_to_forms=None) -> dict:
-    print(f"node: {node}\ntables: {applies_to_tables}\nforms: {applies_to_forms}")
+    logger.debug(
+        f"node: {node}\ntables: {applies_to_tables}\nforms: {applies_to_forms}"
+    )
     if applies_to_tables is None:
         applies_to_tables = []
     if applies_to_forms is None:
@@ -445,6 +447,13 @@ def convert_node(node: dict, applies_to_tables=None, applies_to_forms=None) -> d
         )
 
     if "children" in node:
-        node["children"] = [convert_node(child, applies_to_tables=applies_to_tables, applies_to_forms=applies_to_forms) for child in node["children"]]
+        node["children"] = [
+            convert_node(
+                child,
+                applies_to_tables=applies_to_tables,
+                applies_to_forms=applies_to_forms,
+            )
+            for child in node["children"]
+        ]
 
     return node

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
@@ -43,6 +43,7 @@ def defult_getter(refnr: str, settings: CallbackSettings, field_path: str, *args
             .to_pandas()
         )
     logger.debug(f"Returning:\n{res}")
+    print(f"Returning:\n{res}")
     return res
 
 
@@ -51,6 +52,21 @@ def default_updater(
 ):
     print(f"Updating {field_path}")
     with get_connection() as conn:
+        t = conn.table(settings.form_data_table)
+        res = (
+            t.filter(
+                [
+                    t[settings.form_reference_number_column] == refnr,
+                    t[settings.formdata_fieldname_column] == field_path,
+                ]
+            )
+            .select(settings.formdata_field_value_column_name)
+            .as_scalar()
+            .to_pandas()
+        )
+        if value == res:
+            print(f"Preventing update due to new value '{value}' being identical to old value '{res}'")
+            raise PreventUpdate
         query = f"""
             UPDATE {settings.form_data_table}
             SET {settings.formdata_field_value_column_name} = '{value}'

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
@@ -28,7 +28,7 @@ class CallbackSettings(BaseModel):
 
 
 def defult_getter(refnr: str, settings: CallbackSettings, field_path: str, *args):
-    print(f"Getting {field_path} for refnr: {refnr}")
+    logger.debug(f"Getting {field_path} for refnr: {refnr}")
     with get_connection() as conn:
         t = conn.table(settings.form_data_table)
         res = (
@@ -43,14 +43,13 @@ def defult_getter(refnr: str, settings: CallbackSettings, field_path: str, *args
             .to_pandas()
         )
     logger.debug(f"Returning:\n{res}")
-    print(f"Returning:\n{res}")
     return res
 
 
 def default_updater(
     value, refnr: str, settings: CallbackSettings, field_path: str, *args
 ):
-    print(f"Updating {field_path}")
+    logger.debug(f"Updating {field_path}")
     with get_connection() as conn:
         t = conn.table(settings.form_data_table)
         res = (
@@ -65,7 +64,9 @@ def default_updater(
             .to_pandas()
         )
         if value == res:
-            print(f"Preventing update due to new value '{value}' being identical to old value '{res}'")
+            logger.debug(
+                f"Preventing update due to new value '{value}' being identical to old value '{res}'"
+            )
             raise PreventUpdate
         query = f"""
             UPDATE {settings.form_data_table}
@@ -89,8 +90,12 @@ class EditableField(BaseModel):
         parts = [f"EditableField(path='{self.field_path}')"]
 
         # Functions
-        parts.append(f"getter={getattr(self.getter_func, '__name__', str(self.getter_func))}")
-        parts.append(f"updater={getattr(self.update_func, '__name__', str(self.update_func))}")
+        parts.append(
+            f"getter={getattr(self.getter_func, '__name__', str(self.getter_func))}"
+        )
+        parts.append(
+            f"updater={getattr(self.update_func, '__name__', str(self.update_func))}"
+        )
 
         # Guards
         if self.applies_to_tables or self.applies_to_forms:
@@ -105,7 +110,6 @@ class EditableField(BaseModel):
             guard_states.append(State(settings.table_selector_id, "value"))
         if settings.form_selector_id:
             guard_states.append(State(settings.form_selector_id, "value"))
-        print(f"guard_states: {guard_states}")
         return guard_states
 
     def _check_guard(self, settings: CallbackSettings, *guard_values):
@@ -113,14 +117,11 @@ class EditableField(BaseModel):
         idx = 0
         if settings.table_selector_id and self.applies_to_tables:
             if guard_values[idx] not in self.applies_to_tables:
-                print("Returning False")
                 return False
             idx += 1
         if settings.form_selector_id and self.applies_to_forms:
             if guard_values[idx] not in self.applies_to_forms:
-                print("Returning False")
                 return False
-        print("Returning True")
         return True
 
     def create_callback(

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
@@ -28,6 +28,7 @@ class CallbackSettings(BaseModel):
 
 
 def defult_getter(refnr: str, settings: CallbackSettings, field_path: str, *args):
+    print(f"Getting {field_path} for refnr: {refnr}")
     with get_connection() as conn:
         t = conn.table(settings.form_data_table)
         res = (
@@ -48,6 +49,7 @@ def defult_getter(refnr: str, settings: CallbackSettings, field_path: str, *args
 def default_updater(
     value, refnr: str, settings: CallbackSettings, field_path: str, *args
 ):
+    print(f"Updating {field_path}")
     with get_connection() as conn:
         query = f"""
             UPDATE {settings.form_data_table}
@@ -67,12 +69,27 @@ class EditableField(BaseModel):
     applies_to_tables: list[str] = Field(default_factory=list)
     applies_to_forms: list[str] = Field(default_factory=list)
 
+    def __str__(self) -> str:
+        parts = [f"EditableField(path='{self.field_path}')"]
+
+        # Functions
+        parts.append(f"getter={getattr(self.getter_func, '__name__', str(self.getter_func))}")
+        parts.append(f"updater={getattr(self.update_func, '__name__', str(self.update_func))}")
+
+        # Guards
+        if self.applies_to_tables or self.applies_to_forms:
+            parts.append(f"applies to tables={self.applies_to_tables}")
+            parts.append(f"applies to forms={self.applies_to_forms}")
+
+        return " | ".join(parts)
+
     def _build_guard_states(self, settings: CallbackSettings) -> list[State]:
         guard_states = []
         if settings.table_selector_id:
             guard_states.append(State(settings.table_selector_id, "value"))
         if settings.form_selector_id:
             guard_states.append(State(settings.form_selector_id, "value"))
+        print(f"guard_states: {guard_states}")
         return guard_states
 
     def _check_guard(self, settings: CallbackSettings, *guard_values):
@@ -80,11 +97,14 @@ class EditableField(BaseModel):
         idx = 0
         if settings.table_selector_id and self.applies_to_tables:
             if guard_values[idx] not in self.applies_to_tables:
+                print("Returning False")
                 return False
             idx += 1
         if settings.form_selector_id and self.applies_to_forms:
             if guard_values[idx] not in self.applies_to_forms:
+                print("Returning False")
                 return False
+        print("Returning True")
         return True
 
     def create_callback(
@@ -110,7 +130,6 @@ class EditableField(BaseModel):
             n_guard = len(guard_states)
             guard_values = args[-n_guard:] if n_guard else ()
             real_args = args[:-n_guard] if n_guard else args
-
             if not self._check_guard(settings, *guard_values):
                 logger.debug("Preventing update")
                 raise PreventUpdate

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
@@ -50,7 +50,7 @@ def default_updater(
     value, refnr: str, settings: CallbackSettings, field_path: str, *args
 ):
     logger.debug(f"Updating {field_path}")
-    with get_connection() as conn:
+    with get_connection() as conn: # TODO: Fix this probably unnecessary roundtrip to the database
         t = conn.table(settings.form_data_table)
         res = (
             t.filter(
@@ -175,7 +175,7 @@ class EditableField(BaseModel):
             prevent_initial_call="duplicate",
         )
         def update_field(value, refnr, *args):
-            if ctx.triggered_id != id:
+            if ctx.triggered_id != id: # TODO: Make sure it only triggers on a true update, not just on loading data.
                 raise PreventUpdate
 
             n_guard = len(guard_states)

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/models.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/models.py
@@ -59,10 +59,8 @@ class BaseNode(BaseModel):
             info_parts.append(f"{self.label}")
 
         # field_path for InputField or similar
-        if hasattr(self, "field_settings") and hasattr(
-            self.field_settings, "field_path"
-        ):
-            info_parts.append(f"path={self.field_settings.field_path}")
+        if hasattr(self, "field_settings"):
+            info_parts.append(f"path={self.field_settings}")
 
         # klass_code for KlassDropdown/KlassChecklist
         if hasattr(self, "klass_code"):


### PR DESCRIPTION
This is a temporary quickfix for callbacks firing when they shouldnt. It should be optimized and cleaned up later.
Especially the update callback should be fixed, right now it assumes you are using the default updater which is unfortunate. Should be possible to fix it using callback context.

An alternative is including a dcc.Store to keep the previous value, but that seems too complicated if callback context works.