### PR TITLE
Fix: Add raised tab hover/active effect in dark mode

### DIFF
--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -696,4 +696,28 @@ Hard-coded light colors replaced with darkly-compatible equivalents.
     color: #fff !important;
 }
 
+/*
+Dark mode — raised tabs effect
+Darkly does not include Lumen's nav-tabs raise/hover animation,
+so replicate it here using darkly's own CSS variables.
+*/
+
+.dark-mode .nav-tabs .nav-link,
+.dark-mode .nav-tabs .nav-link.disabled,
+.dark-mode .nav-tabs .nav-link.disabled:focus,
+.dark-mode .nav-tabs .nav-link.disabled:hover {
+    margin-top: 6px;
+    border-color: var(--bs-border-color);
+    transition: padding-bottom .2s ease-in-out, margin-top .2s ease-in-out, border-bottom .2s ease-in-out;
+}
+
+.dark-mode .nav-tabs .nav-link.active,
+.dark-mode .nav-tabs .nav-link:not(.disabled):focus,
+.dark-mode .nav-tabs .nav-link:not(.disabled):hover {
+    padding-bottom: calc(.5rem + 6px);
+    margin-top: 0;
+    color: var(--bs-body-color);
+    border-bottom-color: transparent;
+}
+
 


### PR DESCRIPTION
## Summary of the changes I made:
- Dark mode (Darkly) was missing the raised tab effect that light mode (Lumen) has - inactive tabs stayed flat and hovering only changed the border.
- Ported Lumen's `.nav-tabs .nav-link` rule into `stylesheet.css` under a `.dark-mode` scope, using Darkly's own CSS variables (`--bs-border-color`, `--bs-body-color`) so colors stay theme-correct.
- Inactive tabs now sit 6px lower and animate up on hover/focus/active with the same 0.2s transition as light mode.
