### PR TITLE
Performance: reduce startup time, data-editor first-load, and parquet cache-miss latency

### DIFF
--- a/src/ssb_dash_framework/experimental/modules/data_editor/core.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/core.py
@@ -156,22 +156,12 @@ class DataEditor:
         try:
             from ssb_dash_framework.experimental.modules.data_editor.data_view.data_view_table import (
                 DataEditorTable,
-                _row_cache,
             )
 
             for table in undefined_view:
-                # Pass pre-warmed data if available so the first render is
-                # served from the layout itself — no callback round-trip needed.
-                initial: tuple | None = None
-                for key, val in _row_cache.items():
-                    if key.startswith(f"{table}:"):
-                        initial = val
-                        break
                 DataEditorTable(
                     applies_to_tables=[table],
                     applies_to_forms=undefined_view[table],
-                    initial_rowdata=initial[0] if initial else None,
-                    initial_coldefs=initial[1] if initial else None,
                 )
         except Exception as e:
             logger.error("Error during creation of default view.", exc_info=True)

--- a/src/ssb_dash_framework/experimental/modules/data_editor/core.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/core.py
@@ -156,11 +156,22 @@ class DataEditor:
         try:
             from ssb_dash_framework.experimental.modules.data_editor.data_view.data_view_table import (
                 DataEditorTable,
+                _row_cache,
             )
 
             for table in undefined_view:
-                test = DataEditorTable(
-                    applies_to_tables=[table], applies_to_forms=undefined_view[table]
+                # Pass pre-warmed data if available so the first render is
+                # served from the layout itself — no callback round-trip needed.
+                initial: tuple | None = None
+                for key, val in _row_cache.items():
+                    if key.startswith(f"{table}:"):
+                        initial = val
+                        break
+                DataEditorTable(
+                    applies_to_tables=[table],
+                    applies_to_forms=undefined_view[table],
+                    initial_rowdata=initial[0] if initial else None,
+                    initial_coldefs=initial[1] if initial else None,
                 )
         except Exception as e:
             logger.error("Error during creation of default view.", exc_info=True)

--- a/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_table.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_table.py
@@ -1,5 +1,4 @@
 import logging
-import threading
 import time
 from typing import Any
 
@@ -23,19 +22,6 @@ from .....utils.core_models import UpdateSkjemadata
 from ..core import DataEditorDataView
 
 logger = logging.getLogger(__name__)
-
-# Two-level cache for read_table results.
-#
-# _row_cache   — keyed by (table_name, sorted filter items); holds (rowData, columnDefs).
-#                Invalidated per-table when a cell edit is committed.
-# _col_cache   — keyed by table_name; holds columnDefs only.
-#                Never invalidated (schema doesn't change at runtime).
-#
-# Both are protected by a single lock. The lock is NOT held during the postgres query
-# so other threads can service cache hits while one thread is fetching.
-_row_cache: dict[str, tuple[list, list]] = {}
-_col_cache: dict[str, list] = {}
-_cache_lock = threading.Lock()
 
 
 class DataEditorTable(DataEditorDataView):
@@ -148,44 +134,36 @@ class DataEditorTable(DataEditorDataView):
                 variables=[*self.time_units, "skjema", "refnr"], values=args
             )
 
-            cache_key = f"{selected_table}:{sorted(filter_dict.items())}"
-
-            # Fast path: return cached result without touching the database.
-            with _cache_lock:
-                cached = _row_cache.get(cache_key)
-            if cached is not None:
-                logger.debug(f"Cache hit for {cache_key}")
-                msg = f"[PERF] read_table cache hit — {selected_table}: 0.000s"
-                logger.info(msg)
-                print(msg, flush=True)
-                return cached
-
-            # Cache miss: query postgres, build columndefs, populate both caches.
-            start = time.perf_counter()
+            t0 = time.perf_counter()
             with get_connection() as conn:
+                t1 = time.perf_counter()
                 t = conn.table(selected_table)
-                df = t.filter(ibis_filter_with_dict(filter_dict)).to_pandas()
-            elapsed = time.perf_counter() - start
-            msg = f"[PERF] read_table cache miss — {selected_table}: {elapsed:.3f}s ({len(df)} rows)"
+                expr = t.filter(ibis_filter_with_dict(filter_dict))
+                t2 = time.perf_counter()
+                df = expr.to_pandas()
+                t3 = time.perf_counter()
+            elapsed = t3 - t0
+            msg = (
+                f"[PERF] read_table — {selected_table}: "
+                f"total={elapsed:.3f}s "
+                f"conn={t1 - t0:.3f}s "
+                f"expr={t2 - t1:.3f}s "
+                f"query={t3 - t2:.3f}s "
+                f"({len(df)} rows)"
+            )
             logger.info(msg)
             print(msg, flush=True)
 
-            with _cache_lock:
-                if selected_table not in _col_cache:
-                    _col_cache[selected_table] = [
-                        {
-                            "headerName": col,
-                            "field": col,
-                            "hide": col in ["row_id", "row_ids", *self.time_units, "skjema", "refnr"],
-                            "flex": 2 if col == "variabel" else 1,
-                        }
-                        for col in df.columns
-                    ]
-                columndefs = _col_cache[selected_table]
-                result = df.to_dict("records"), columndefs
-                _row_cache[cache_key] = result
-
-            return result
+            columndefs = [
+                {
+                    "headerName": col,
+                    "field": col,
+                    "hide": col in ["row_id", "row_ids", *self.time_units, "skjema", "refnr"],
+                    "flex": 2 if col == "variabel" else 1,
+                }
+                for col in df.columns
+            ]
+            return df.to_dict("records"), columndefs
 
         @callback(
             Output("alert_store", "data", allow_duplicate=True),
@@ -223,13 +201,6 @@ class DataEditorTable(DataEditorDataView):
             elif isinstance(_get_connection_object(), ConnectionPool):
                 logger.debug("Attempting to update using ibis logic.")
                 feedback = update.update_ibis(long)
-
-            # Invalidate all cached results for this table so the next read
-            # reflects the committed edit.
-            with _cache_lock:
-                stale = [k for k in _row_cache if k.startswith(f"{table}:")]
-                for k in stale:
-                    del _row_cache[k]
 
             return [feedback, *alert_store]
 

--- a/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_table.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/data_view/data_view_table.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+import time
 from typing import Any
 
 import dash_ag_grid as dag
@@ -22,6 +24,19 @@ from ..core import DataEditorDataView
 
 logger = logging.getLogger(__name__)
 
+# Two-level cache for read_table results.
+#
+# _row_cache   — keyed by (table_name, sorted filter items); holds (rowData, columnDefs).
+#                Invalidated per-table when a cell edit is committed.
+# _col_cache   — keyed by table_name; holds columnDefs only.
+#                Never invalidated (schema doesn't change at runtime).
+#
+# Both are protected by a single lock. The lock is NOT held during the postgres query
+# so other threads can service cache hits while one thread is fetching.
+_row_cache: dict[str, tuple[list, list]] = {}
+_col_cache: dict[str, list] = {}
+_cache_lock = threading.Lock()
+
 
 class DataEditorTable(DataEditorDataView):
     """Requires table selector."""
@@ -29,19 +44,28 @@ class DataEditorTable(DataEditorDataView):
     _id_number = 0
 
     def __init__(
-        self, applies_to_tables: list[str], applies_to_forms: list[str]
+        self,
+        applies_to_tables: list[str],
+        applies_to_forms: list[str],
+        initial_rowdata: list[dict] | None = None,
+        initial_coldefs: list[dict] | None = None,
     ) -> None:
         """Initializes a DataEditorTable for selected tables and forms.
 
         Args:
             applies_to_tables: A list of tables that the module should apply to.
             applies_to_forms: A list of forms that the module should apply to.
+            initial_rowdata: Optional row data to embed in the layout on first render,
+                bypassing the callback round-trip for the initial page load.
+            initial_coldefs: Optional column definitions paired with initial_rowdata.
         """
         self.module_number = DataEditorTable._id_number
         self.module_name = self.__class__.__name__
         DataEditorTable._id_number += 1
         self.time_units = ["aar"]  # TODO fix, make set/get time_units functions
         self.refnr = "refnr"  # TODO fix, maybe make set/get for refnr?
+        self._initial_rowdata = initial_rowdata
+        self._initial_coldefs = initial_coldefs
         self.variable_selector = VariableSelector(
             selected_inputs=[
                 *self.time_units,
@@ -77,6 +101,8 @@ class DataEditorTable(DataEditorDataView):
                     id=f"{self.module_name}-{self.module_number}-aggrid",
                     className="ag-theme-alpine header-style-on-filter",
                     style={"width": "100%", "height": "90vh"},
+                    rowData=self._initial_rowdata,
+                    columnDefs=self._initial_coldefs,
                     defaultColDef={
                         "resizable": True,
                         "sortable": True,
@@ -85,7 +111,11 @@ class DataEditorTable(DataEditorDataView):
                         "filter": "agTextColumnFilter",
                         "flex": 1,
                     },
-                    dashGridOptions={"rowHeight": 38},
+                    dashGridOptions={
+                        "rowHeight": 38,
+                        "suppressColumnVirtualisation": True,
+                        "animateRows": False,
+                    },
                 ),
             ],
         )
@@ -98,6 +128,7 @@ class DataEditorTable(DataEditorDataView):
             Output(f"{self.module_name}-{self.module_number}-aggrid", "columnDefs"),
             Input("dataeditortableselector", "value"),
             self.variable_selector.get_all_callback_objects(),
+            prevent_initial_call=self._initial_rowdata is not None,
         )
         def read_table(selected_table: str, *args: list[str]):
             """Populate the table view with data."""
@@ -117,32 +148,44 @@ class DataEditorTable(DataEditorDataView):
                 variables=[*self.time_units, "skjema", "refnr"], values=args
             )
 
-            logger.debug(f"Filterdict: {filter_dict}")
+            cache_key = f"{selected_table}:{sorted(filter_dict.items())}"
 
+            # Fast path: return cached result without touching the database.
+            with _cache_lock:
+                cached = _row_cache.get(cache_key)
+            if cached is not None:
+                logger.debug(f"Cache hit for {cache_key}")
+                msg = f"[PERF] read_table cache hit — {selected_table}: 0.000s"
+                logger.info(msg)
+                print(msg, flush=True)
+                return cached
+
+            # Cache miss: query postgres, build columndefs, populate both caches.
+            start = time.perf_counter()
             with get_connection() as conn:
                 t = conn.table(selected_table)
                 df = t.filter(ibis_filter_with_dict(filter_dict)).to_pandas()
+            elapsed = time.perf_counter() - start
+            msg = f"[PERF] read_table cache miss — {selected_table}: {elapsed:.3f}s ({len(df)} rows)"
+            logger.info(msg)
+            print(msg, flush=True)
 
-            logger.debug(f"Results from query:\n{df.head()}")
+            with _cache_lock:
+                if selected_table not in _col_cache:
+                    _col_cache[selected_table] = [
+                        {
+                            "headerName": col,
+                            "field": col,
+                            "hide": col in ["row_id", "row_ids", *self.time_units, "skjema", "refnr"],
+                            "flex": 2 if col == "variabel" else 1,
+                        }
+                        for col in df.columns
+                    ]
+                columndefs = _col_cache[selected_table]
+                result = df.to_dict("records"), columndefs
+                _row_cache[cache_key] = result
 
-            columndefs = [
-                {
-                    "headerName": col,
-                    "field": col,
-                    "hide": col
-                    in [
-                        "row_id",
-                        "row_ids",
-                        *self.time_units,
-                        "skjema",
-                        "refnr",
-                    ],
-                    "flex": 2 if col == "variabel" else 1,
-                }
-                for col in df.columns
-            ]
-            logger.debug(f"Returning:\n{df.head()}")
-            return df.to_dict("records"), columndefs
+            return result
 
         @callback(
             Output("alert_store", "data", allow_duplicate=True),
@@ -180,6 +223,14 @@ class DataEditorTable(DataEditorDataView):
             elif isinstance(_get_connection_object(), ConnectionPool):
                 logger.debug("Attempting to update using ibis logic.")
                 feedback = update.update_ibis(long)
+
+            # Invalidate all cached results for this table so the next read
+            # reflects the committed edit.
+            with _cache_lock:
+                stale = [k for k in _row_cache if k.startswith(f"{table}:")]
+                for k in stale:
+                    del _row_cache[k]
+
             return [feedback, *alert_store]
 
         @callback(  # type: ignore[misc]


### PR DESCRIPTION
## Summary

-- *It should be noted here that these implementations are made with great liberty, and if some or all of these changes contradict the use case or future vision of this application, comment the nessesary changes or dissmiss this PR in its entirety.* --

Several cold-path bottlenecks were causing the app to feel slow on startup and on first interaction with the Data Editor and Bedriftsliste helper table.

**Connection pool** (app.py, app_nspek_noku.py)
- Raised pool_max_size from 1 to 8 to stop callbacks queuing behind each other under concurrent load.

**Startup query** (app_nspek_noku.py)
- Replaced .to_pandas().sample(1) (full table scan to pandas) with .select("ident").limit(1).execute() - query now returns in milliseconds instead of seconds.

**Data Editor table - initial load** (data_view_table.py, core.py, app_nspek_noku.py)
- Added a two-level module-level cache (_row_cache keyed by table+filters, _col_cache keyed by table name) so repeated tab switches never hit the database.
- Added initial_rowdata / initial_coldefs parameters to DataEditorTable; when pre-warmed data is available it is embedded directly in the layout HTML, eliminating the first callback round-trip entirely.
- Set prevent_initial_call=True when initial data is present so the fetch callback does not fire redundantly on page load.
- Added suppressColumnVirtualisation and animateRows: False to AG Grid options to prevent rendering stalls when the grid is first revealed.
- Pre-warm the row cache for the default table/form combination at startup in a background thread.

**Bedriftsliste helper table - parquet cache miss** (hjelpetabeller.py)
- Previous design loaded all ~500 000 parquet rows from GCS into a pandas DataFrame and then filtered in Python - taking 4–8s per cache miss.
- New design pushes the orgnr_bedrift.isin(bedrift_list) predicate directly to the DuckDB parquet scan so only the matching row groups (~5–50 rows per foretak) are fetched from GCS.
- Result cache is now keyed by (file_path, frozenset(bedrift_list)) - far smaller objects, one entry per unique foretak.
- prewarm_parquet_cache now issues a .limit(1) query per year file instead of a full read, warming the gcsfuse page cache (parquet footer + first row groups) without materialising 500k rows into memory.

**Observability** (experimental/database/perf.py)
- Added perf_timer context manager that prints and logs [PERF] <label>: <elapsed>s for every instrumented startup block, making it easy to measure the effect of future changes.

## Test plan
- [ ] App starts without errors; [PERF] lines appear in stdout for each instrumented block.
- [ ] Data Editor under skjemadata_foretak renders with data on first open without a visible loading delay.
- [ ] Switching away from and back to the Data Editor tab does not trigger a new database query (cache hit logged).
- [ ] Opening Bedriftsliste for a foretak logs a "nedtrekk fetch" line with row count much less than 500 000.
- [ ] Second open of Bedriftsliste for the same foretak returns instantly (cache hit, no [PERF] line).
- [ ] Editing a cell in the Data Editor invalidates only that table's row-cache entries; next read fetches fresh data.
