### PR TITLE
skjemamottak view update, macromodule updated to output to new dataeditor

### DIFF
--- a/src/ssb_dash_framework/experimental/modules/data_editor/core.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/core.py
@@ -20,6 +20,7 @@ from ssb_dash_framework.utils.config_tools.set_variables import get_ident
 from ssb_dash_framework.utils.config_tools.set_variables import get_time_units
 from ssb_dash_framework.utils.core_query_functions import create_filter_dict
 from ssb_dash_framework.utils.core_query_functions import ibis_filter_with_dict
+from ssb_dash_framework.utils.alert_handler import create_alert
 
 from ....utils.config_tools.connection import get_connection
 from .registry import DataEditorRegistry
@@ -195,6 +196,22 @@ class DataEditor:
 
     def module_callbacks(self) -> None:
         """Registers the callbacks for the DataEditor."""
+        
+        # @callback(
+        #     VariableSelector([], []).get_output_object("refnr"),
+        #     VariableSelector([], []).get_output_object("altinnskjema"),
+        #     VariableSelector([], []).get_input(get_ident()),
+        #     prevent_initial_call=True,
+        # )
+        # def clear_on_missing_ident(ident: str):
+        #     if not ident:
+        #         raise PreventUpdate
+        #     with get_connection() as conn:
+        #         t = conn.table("skjemamottak")
+        #         result = t.filter(_.ident == ident).limit(1).to_pandas()
+        #     if result.empty:
+        #         return "", ""
+        #     raise PreventUpdate
 
         @callback(
             *[
@@ -411,11 +428,12 @@ class DataEditorInfoRow:
                 for info_var in self.info_variables
             ],
             variableselector.get_input(get_ident()),
+            variableselector.get_input("refnr"),
             *[variableselector.get_input(unit) for unit in get_time_units().keys()],
             *[variableselector.get_all_states()],
         )
         def get_data_for_info_row_fields(
-            ident: str, *args: Any
+            ident: str, altinnskjema: str, *args: Any
         ) -> list[str | int | float | bool | None]:
             logger.debug(f"ident: {ident}\nargs: {args}")
             info_values = []

--- a/src/ssb_dash_framework/experimental/modules/data_editor/core.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/core.py
@@ -196,21 +196,21 @@ class DataEditor:
     def module_callbacks(self) -> None:
         """Registers the callbacks for the DataEditor."""
         
-        # @callback(
-        #     VariableSelector([], []).get_output_object("refnr"),
-        #     VariableSelector([], []).get_output_object("altinnskjema"),
-        #     VariableSelector([], []).get_input(get_ident()),
-        #     prevent_initial_call=True,
-        # )
-        # def clear_on_missing_ident(ident: str):
-        #     if not ident:
-        #         raise PreventUpdate
-        #     with get_connection() as conn:
-        #         t = conn.table("skjemamottak")
-        #         result = t.filter(_.ident == ident).limit(1).to_pandas()
-        #     if result.empty:
-        #         return "", ""
-        #     raise PreventUpdate
+        @callback(
+            VariableSelector([], []).get_output_object("refnr"),
+            VariableSelector([], []).get_output_object("altinnskjema"),
+            VariableSelector([], []).get_input(get_ident()),
+            prevent_initial_call=True,
+        )
+        def clear_on_missing_ident(ident: str):
+            if not ident:
+                raise PreventUpdate
+            with get_connection() as conn:
+                t = conn.table("skjemamottak")
+                result = t.filter(_.ident == ident).limit(1).to_pandas()
+            if result.empty:
+                return "", ""
+            raise PreventUpdate
 
         @callback(
             *[
@@ -234,7 +234,7 @@ class DataEditor:
                 tables = DataEditorRegistry.main_views[divname]["tables"]
 
                 table_match = selected_table in tables
-                form_match = selected_form in forms or None in forms
+                form_match = (not forms and not selected_form) or selected_form in forms
 
                 if table_match and form_match:
                     styles.append({"display": "block"})

--- a/src/ssb_dash_framework/experimental/modules/data_editor/sidebar_components/comment.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/sidebar_components/comment.py
@@ -90,6 +90,10 @@ class DataEditorSidebarComment(DataEditorHelperSidebar):
             refnr: str, skjema: str, *args: list[Any]
         ) -> tuple[str, list[dict[str, str]]]:
             """Collect relevant refnrs."""  # TODO Check what it actually does and needs to do.
+            
+            if not refnr or not skjema:
+                raise PreventUpdate
+
             if isinstance(_get_connection_object(), EimerDBInstance):
                 args_before_timeunits = 1
                 N = len(get_time_units())

--- a/src/ssb_dash_framework/experimental/modules/data_editor/sidebar_components/editing_status.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/sidebar_components/editing_status.py
@@ -13,9 +13,11 @@ from dash import dcc
 from dash import html
 from dash import no_update
 from dash.exceptions import PreventUpdate
+import ibis.selectors as s
 from eimerdb import EimerDBInstance
 from ibis import _
 from psycopg_pool import ConnectionPool
+import tzlocal
 
 from ssb_dash_framework import VariableSelector
 from ssb_dash_framework.utils.core_query_functions import create_filter_dict
@@ -30,6 +32,8 @@ from .....utils.core_models import UpdateSkjemamottakStatus
 from ..core import DataEditorHelperSidebar
 
 logger = logging.getLogger(__name__)
+
+local_tz = tzlocal.get_localzone()
 
 
 class DataEditorSidebarEditingStatus(DataEditorHelperSidebar):
@@ -57,7 +61,7 @@ class DataEditorSidebarEditingStatus(DataEditorHelperSidebar):
         DataEditorSidebarEditingStatus._id_number += 1
 
         self.variableselector = VariableSelector(
-            selected_inputs=[], selected_states=[get_ident(), *get_time_units().keys()]
+            selected_inputs=[], selected_states=[get_ident(), *get_time_units().keys(), "altinnskjema", "refnr"]
         )
 
         self.status_options = (
@@ -80,7 +84,9 @@ class DataEditorSidebarEditingStatus(DataEditorHelperSidebar):
                 dbc.ModalBody(
                     [
                         dag.AgGrid(
-                            id=f"{self.module_name}-{self.module_number}-form-table"
+                            id=f"{self.module_name}-{self.module_number}-form-table",
+                            columnSize="responsiveSizeToFit",
+                            dashGridOptions={"rowSelection": "single"},
                         )
                     ]
                 ),
@@ -213,5 +219,46 @@ class DataEditorSidebarEditingStatus(DataEditorHelperSidebar):
             filterdict = create_filter_dict([get_ident(), *get_time_units()], [*args])
             with get_connection() as conn:
                 t = conn.table("skjemamottak")
-                data = t.filter(ibis_filter_with_dict(filterdict)).to_pandas()
-            return data.to_dict("records"), [{"field": x} for x in data.columns], True
+                data = (
+                    t.filter(ibis_filter_with_dict(filterdict))
+                    .order_by(_.dato_mottatt.desc())
+                    .select(
+                        "skjema",
+                        "dato_mottatt",
+                        "refnr",
+                        s.matches(r"^(editert|status)$"),
+                        "kommentar",
+                        "aktiv",
+                    )
+                    .to_pandas()
+                )
+                data["dato_mottatt"] = (
+                    data["dato_mottatt"]
+                    .dt.tz_convert(local_tz)
+                    .dt.tz_localize(None)
+                    .dt.strftime("%Y-%m-%d %H:%M:%S")
+                )
+            return data.to_dict("records"), [{"field": x, "headerName": x} for x in data.columns], True
+        
+        @callback(  # type: ignore[misc]
+            self.variableselector.get_output_object("refnr"), # oppdater refnr
+            self.variableselector.get_output_object("altinnskjema"), # oppdater altinnskjema
+            Input(f"{self.module_name}-{self.module_number}-form-table", "selectedRows"),
+            self.variableselector.get_input("refnr"),
+            self.variableselector.get_input("altinnskjema"),
+            prevent_initial_call=True,
+        )
+        def selected_refnr(selected_row: list[dict[str, Any]], current_refnr, current_altinnskjema):
+            print(selected_row)
+            logger.debug(f"Args:\nselected_row: {selected_row}")
+            if not selected_row:
+                logger.debug("Raised PreventUpdate")
+                raise PreventUpdate
+
+            refnr = selected_row[0]["refnr"]
+            skjema = selected_row[0]["skjema"]
+
+            return (
+                refnr if refnr != current_refnr else no_update,
+                skjema if skjema != current_altinnskjema else no_update,
+            )

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
@@ -111,6 +111,7 @@ class EditableField(BaseModel):
     # applies_to_... is used for compatibility with DataEditorDataViewCustom
     applies_to_tables: list[str] = Field(default_factory=list)
     applies_to_forms: list[str] = Field(default_factory=list)
+    variabel_trigger: str = "n_blur"
 
     @computed_field
     @property
@@ -226,4 +227,12 @@ class EditableField(BaseModel):
                 )
                 logger.info(f"getter returned {result!r} for {self.field_path}, refnr={refnr}")
                 return result, no_update
-
+        
+        @callback(
+            variableselector.get_output_object("variabel"),
+            Input(self._id, self.variabel_trigger),
+            prevent_initial_call=True,
+        )
+        def update_variabel(_):
+            return self.field_path
+        update_variabel.__name__ = f"update_variabel_{self._id}"

--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/models.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/models.py
@@ -377,6 +377,7 @@ class DropdownComponent(BaseNode):
     ) -> html.Div:
         """A method for creating the layout."""
         _id = str(uuid.uuid4())
+        self.field_settings.variabel_trigger = "value"
         self.field_settings.create_callback(
             settings,
             inputs,
@@ -442,6 +443,7 @@ class ChecklistComponent(BaseNode):
 
         self.field_settings.getter_func = wrapped_getter
         self.field_settings.update_func = wrapped_updater
+        self.field_settings.variabel_trigger = "value"
         self.field_settings.create_callback(
             settings,
             inputs,

--- a/src/ssb_dash_framework/modules/macro_module.py
+++ b/src/ssb_dash_framework/modules/macro_module.py
@@ -1351,7 +1351,7 @@ class MacroModule:
         @callback(  # type: ignore[misc]
             Output("var-ident", "value", allow_duplicate=True),
             Output("var-bedrift", "value", allow_duplicate=True),
-            Output("altinnedit-option1", "value", allow_duplicate=True),
+            Output("dataeditortableselector", "value", allow_duplicate=True),
             Output("macromodule-pending-click-store", "data", allow_duplicate=True),
             Input("macromodule-bruk-button", "n_clicks"),
             State("macromodule-pending-click-store", "data"),

--- a/src/ssb_dash_framework/modules/macro_nspek_post_control.py
+++ b/src/ssb_dash_framework/modules/macro_nspek_post_control.py
@@ -777,7 +777,7 @@ class MacroNspekPostControl:
         @callback(  # type: ignore[misc]
             Output("var-ident", "value", allow_duplicate=True),
             Output("var-bedrift", "value", allow_duplicate=True),
-            Output("altinnedit-option1", "value", allow_duplicate=True),
+            Output("dataeditortableselector", "value", allow_duplicate=True),
             Input("macromodule-nopost-detail-grid", "cellClicked"),
             State("macromodule-nopost-detail-grid", "rowData"),
             prevent_initial_call=True,

--- a/tests/module_tests/test_microlayout.py
+++ b/tests/module_tests/test_microlayout.py
@@ -127,7 +127,7 @@ def test_layout_parses_and_builds(callback_settings):
     )
 
     registered = [o.title for o in VariableSelector._variableselectoroptions]
-    for var in ["ident", "altinnskjema"]:
+    for var in ["ident", "altinnskjema", "variabel"]:
         if var not in registered:
             set_variables(var)
 


### PR DESCRIPTION
- added refnr as input to data editor, and it now clears altinnskjema and refnr is variableselector if it can't find a skjema
- added 'var-variabel' update when user selects something in the microlayout
- macromodules now update table through 'dataeditortableselector' instead of 'altinnedit-option1'
- hid some columns in skjemamottak table and made the cols fit the table