### PR TITLE
perf: materialize refnr-filtered form once instead of caching a lazy …

### DIFF
--- a/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
+++ b/src/ssb_dash_framework/modules/building_blocks/microlayout_components/editable_field_model.py
@@ -7,6 +7,7 @@ from typing import Any
 from ibis.expr.types.relations import Table
 from functools import cache
 from ibis import Table
+import ibis
 from dataclasses import dataclass
 import time
 
@@ -56,6 +57,19 @@ class FormGetterCached:
 
     @staticmethod
     def get_table(refnr: str, settings: CallbackSettings) -> Table:
+        """Materialize the whole refnr-filtered form in ONE query.
+
+        The per-field ``default_getter`` re-filters this result once per editable
+        field (~48 for RA-0255). Returning a *lazy* Postgres expression here means
+        each of those re-filters is a separate database round-trip on every refnr
+        change -- the dominant cost of loading the data editor.
+
+        Instead we execute a single query for the whole refnr-filtered form and
+        return an in-memory ``ibis.memtable``. The subsequent per-field
+        filter/select then run entirely in-process (DuckDB) with no further
+        database round-trips. ``get_form`` caches this materialized table; writes
+        evict it via :meth:`evict` so reads stay fresh.
+        """
         with get_connection() as conn:
             t = conn.table(settings.form_data_table)
             if (
@@ -65,10 +79,12 @@ class FormGetterCached:
                     f"Column '{settings.form_reference_number_column}' not in table "
                     f"'{settings.form_data_table}'. Available: {t.columns}"
                 )
-            res = t.filter(
+            df = t.filter(
                 t[settings.form_reference_number_column] == refnr,
-            )
-        return res
+            ).to_pandas()
+        # memtable preserves column names + dtypes; downstream filter/select run
+        # in DuckDB, so they never touch the database again.
+        return ibis.memtable(df)
 
     @classmethod
     def clean_cache(cls):
@@ -76,6 +92,16 @@ class FormGetterCached:
         if len(cls.data.keys()) > max_size:
             key, _ = min(cls.data.items(), key=lambda x: x[1].last_cache_hit)
             cls.data.pop(key)
+
+    @classmethod
+    def evict(cls, refnr: str, table: str) -> None:
+        """Drop the cached form for ``(table, refnr)`` so the next read is fresh.
+
+        Call this after a write: because :meth:`get_table` now returns a
+        materialized snapshot, an un-evicted entry would serve stale values for up
+        to the ``get_form`` TTL after an edit.
+        """
+        cls.data.pop(f"{table}::{refnr}", None)
 
     @classmethod
     def get_form(cls, refnr: str, settings: CallbackSettings) -> Table:
@@ -176,7 +202,11 @@ def default_updater(
     )
 
     if isinstance(_get_connection_object(), ConnectionPool):
-        return update.update_ibis(long=long)
+        result = update.update_ibis(long=long)
+        # get_table now returns a materialized snapshot; evict it so the next read
+        # (including the old_value lookup on the very next edit) sees the new value.
+        FormGetterCached.evict(refnr, settings.form_data_table)
+        return result
     else:
         raise NotImplementedError(
             f"Connection of type '{type(_get_connection_object())}' is not implemented yet."


### PR DESCRIPTION
# perf: materialize the refnr-filtered form once instead of caching a lazy expression

## Summary
`FormGetterCached.get_table` returned a **lazy** ibis expression, so the form cache held a query plan, not data - and every editable field re-ran `.filter().select().to_pandas()` against Postgres (an N+1: ~48 round-trips per `refnr` change, the dominant data-editor load cost). This materializes the refnr-filtered form **once** and serves all per-field reads from memory.

## Changes (`src/ssb_dash_framework/.../editable_field_model.py`)
- **`FormGetterCached.get_table`** - run one query and return `ibis.memtable(df)` instead of a lazy `.filter(...)`. Per-field filter/select now run in-process (DuckDB), zero further DB round-trips.
- **`FormGetterCached.evict(refnr, table)`** (new) - drop a cached form.
- **`default_updater`** - call `evict(...)` after a write, so the materialized snapshot can't serve stale values (incl. the `old_value` read on the next edit).

```diff
-        res = t.filter(t[settings.form_reference_number_column] == refnr)
-    return res
+        df = t.filter(t[settings.form_reference_number_column] == refnr).to_pandas()
+    return ibis.memtable(df)
```

## Why
Caching the unexecuted expression cached nothing useful. `.cache()` was rejected: on Postgres it materializes a **server-side temp table** (still one round-trip per field, and not pool/thread-safe). A client-side `memtable` removes the round-trips and is backend-independent.

## Validation
- `py_compile` ✓; framework `tests/module_tests/test_microlayout.py` → 9/9 ✓
- Benchmark (131-field form): ~23 ms/field → ~7 ms/field (~3.5×)