### PR TITLE
DataEditorContactInfo: contact info available, added button-indicators

### DIFF
--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -1042,7 +1042,7 @@ ssb-input
   cursor: text;
   font-size: 14px;
   margin-bottom: 5px;
-  user-select: none;
+  user-select: text;
 }
 .ssb-input input {
   font-family: "Roboto", sans-serif !important;
@@ -2078,6 +2078,25 @@ Altinn Editor Support Tables
 DataEditor 
 */
 
+.helper-button-indicator {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    background: #3396D2;
+    color: #fff;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    text-align: center;
+    padding-top: 3px;
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
+}
+
 .DataEditorHistory-toggle-bar {
     display: flex;
     flex-direction: column;
@@ -2172,6 +2191,13 @@ DataEditor
 .DataEditor-main-view h4 {
     font-size: 1rem;
     font-weight: bold;
+}
+
+.DataEditorContactInfo-body {
+  padding: 15px
+}
+.DataEditorContactInfo-body .col {
+  padding: 10px
 }
 
 .DataEditorInfoRow-info-row .card,

--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -2087,7 +2087,8 @@ DataEditor
 }
 
 .DataEditorHistory-helper-modal .modal-dialog,
-.DataEditorSupportTables-helper-modal .modal-dialog {
+.DataEditorSupportTables-helper-modal .modal-dialog,
+.DataEditorContactInfo-helper-modal .modal-dialog {
     max-width: 90vw !important;
     width: 90vw !important;
 }

--- a/src/ssb_dash_framework/experimental/modules/data_editor/core.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/core.py
@@ -535,11 +535,22 @@ class DataEditorHelperButton:
             raise AttributeError("Lacking 'modal_body' attribute.")
         return html.Div(
             [
-                dbc.Button(
-                    self.label,
-                    id=f"{self.module_name}-{self.module_number}-button",
-                    className="ssb-btn primary-btn",
-                ),
+            html.Div(
+                [
+                    dbc.Button(
+                        self.label,
+                        id=f"{self.module_name}-{self.module_number}-button",
+                        className="ssb-btn primary-btn",
+                    ),
+                    html.Span(
+                        id=f"{self.module_name}-{self.module_number}-indicator",
+                        className="helper-button-indicator",
+                        children="",
+                        style={"display": "none"},
+                    ),
+                ],
+                style={"position": "relative", "display": "inline-block"},
+            ),
                 dbc.Modal(
                     [
                         dbc.ModalHeader(dbc.ModalTitle(self.label)),

--- a/src/ssb_dash_framework/experimental/modules/data_editor/helper_buttons/contact_info.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/helper_buttons/contact_info.py
@@ -1,0 +1,221 @@
+import logging
+from typing import Any
+import dash_ag_grid as dag
+import pandas as pd
+import tzlocal
+from dash import Input
+from dash import Output
+from dash import callback
+from dash import html
+from ibis import _
+from psycopg_pool import ConnectionPool
+import dash_bootstrap_components as dbc
+from dash import dcc
+
+from ssb_dash_framework import VariableSelector
+from ssb_dash_framework.utils.config_tools.set_variables import get_refnr
+from ssb_dash_framework.utils.config_tools.set_variables import get_time_units
+
+from ssb_dash_framework.utils.config_tools.set_variables import get_ident
+from ssb_dash_framework.utils.core_query_functions import create_filter_dict, ibis_filter_with_dict
+
+from  ssb_dash_framework.utils.config_tools.connection import _get_connection_object
+from  ssb_dash_framework.utils.config_tools.connection import get_connection
+from ..core import DataEditorHelperButton
+
+logger = logging.getLogger(__name__)
+
+local_tz = tzlocal.get_localzone()
+
+
+class DataEditorContactInfo(DataEditorHelperButton):
+    """This module provides supporting tables for the DataEditor.
+
+    It adds a button that opens a modal with contact info for the delivered Altinn 3 survey.
+    """
+
+    _id_number = 0
+
+    def __init__(
+        self,
+        applies_to_tables: list[str] | None = None,
+        applies_to_forms: list[str] | None = None,
+    ) -> None:
+        """Initializes the DataEditorContactInfo module."""
+        self.module_number = DataEditorContactInfo._id_number
+        self.module_name = self.__class__.__name__
+        DataEditorContactInfo._id_number += 1
+        self.variableselector = VariableSelector(
+            selected_inputs=[],
+            selected_states=[get_refnr(), *[x for x in get_time_units().keys()]],
+        )
+        self.modal_body = self._create_modal_body()
+
+        super().__init__(label="Kontaktinfo")
+
+        self.module_callbacks()
+
+    def create_info_card(self, title: str, component_id: str, var_type: str):
+        card_info = html.Div(
+            className="ssb-input",
+            children=[
+                html.Label(title),
+                html.Div(
+                    className="input-wrapper",
+                    children=[
+                        dbc.Input(
+                            id=component_id,
+                            type=var_type,
+                        )
+                    ],
+                ),
+            ],
+        )
+        return card_info
+
+    def _create_modal_body(self) -> html.Div:
+        return html.Div(
+            html.Div(
+                [
+                    dbc.Row(
+                        [
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="Organisasjonsnummer",
+                                    component_id="dataeditor-kontaktinfo-card-organisasjonsnummer",
+                                    var_type="text",
+                                ),
+                                width=2,
+                            ),
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="Skjema",
+                                    component_id="dataeditor-kontaktinfo-card-skjema",
+                                    var_type="text",
+                                ),
+                                width=2,
+                            ),
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="Kontaktperson",
+                                    component_id="dataeditor-kontaktinfo-card-kontaktperson",
+                                    var_type="number",
+                                ),
+                                width=2,
+                            ),
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="E-post",
+                                    component_id="dataeditor-kontaktinfo-card-epost",
+                                    var_type="text",
+                                ),
+                                width=2,
+                            ),
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="Telefon",
+                                    component_id="dataeditor-kontaktinfo-card-tlf",
+                                    var_type="text",
+                                ),
+                                width=2,
+                            ),
+                        ],
+                        className="g-2 align-items-end",
+                    ),
+                    dbc.Row(
+                        [
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="Kommentar kontaktinfo",
+                                    component_id="dataeditor-kontaktinfo-card-kommentar",
+                                    var_type="text",
+                                ),
+                                width=2,
+                            ),
+                            dbc.Col(
+                                self.create_info_card(
+                                    title="Kommentar krevende",
+                                    component_id="dataeditor-kontaktinfo-card-krevende",
+                                    var_type="text",
+                                ),
+                                width=2,
+                            ),
+                        ],
+                        className="g-2 align-items-end",
+                    ),
+                ]
+            ),
+            className=f"{self.module_name}-body",
+        )
+
+    def module_callbacks(self):
+        connection_object = _get_connection_object()
+        variableselector = VariableSelector(
+            selected_inputs=["ident", *get_time_units().keys()],
+            selected_states=[],
+        )
+
+        @callback(
+            Output(
+                component_id="dataeditor-kontaktinfo-card-organisasjonsnummer",
+                component_property="value",
+            ),
+            Output(component_id="dataeditor-kontaktinfo-card-skjema", component_property="value"),
+            Output(
+                component_id="dataeditor-kontaktinfo-card-kontaktperson",
+                component_property="value",
+            ),
+            Output(
+                component_id="dataeditor-kontaktinfo-card-epost", component_property="value"
+            ),
+            Output(component_id="dataeditor-kontaktinfo-card-tlf", component_property="value"),
+            Output(component_id="dataeditor-kontaktinfo-card-kommentar", component_property="value"),
+            Output(
+                component_id="dataeditor-kontaktinfo-card-krevende", component_property="value"
+            ),
+            variableselector.get_input(get_ident()),
+            *[variableselector.get_input(unit) for unit in get_time_units().keys()],
+
+        )
+        def create_info_cards_kontaktinfo(ident: str, *args: Any) -> tuple[str, str, str, str, str, str, str]:
+            """Returns a tuple of strings with the values for info cards for the kontaktinfo module in DataEditor.
+            These cards will hold kontaktinfo foretak.
+            """
+            time_unit_list = [x for x in get_time_units().keys()]
+            time_units = args[: len(time_unit_list)]
+            print(time_units)
+
+            filter_dict = create_filter_dict(time_unit_list, time_units)
+            print(filter_dict)
+
+            if isinstance(connection_object, ConnectionPool):
+                logger.debug("Using ConnectionPool logic.")
+                with get_connection(necessary_tables=["kontaktinfo"]) as conn:
+                    t = conn.table("kontaktinfo")
+                    data = t.filter(_.ident == ident).filter(
+                            ibis_filter_with_dict(filter_dict)
+                        ).execute()
+                print(data)
+
+                orgnr = data["ident"].iloc[0]
+                skjema = data["skjema"].iloc[0]
+                kontaktperson = data["kontaktperson"].iloc[0]
+                epost = data["epost"].iloc[0]
+                tlf = data["telefon"].iloc[0]
+                kommentar_kontaktinfo = data["kommentar_kontaktinfo"].iloc[0]
+                kommentar_krevende = data["kommentar_krevende"].iloc[0]
+
+                return (
+                    orgnr,
+                    skjema,
+                    kontaktperson,
+                    epost,
+                    tlf,
+                    kommentar_kontaktinfo,
+                    kommentar_krevende,
+                )
+
+            else:
+                raise NotImplementedError(
+                    f"Connection of type {type(connection_object)} is not currently supported."
+                )

--- a/src/ssb_dash_framework/experimental/modules/data_editor/helper_buttons/contact_info.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/helper_buttons/contact_info.py
@@ -7,6 +7,7 @@ from dash import Input
 from dash import Output
 from dash import callback
 from dash import html
+from dash.exceptions import PreventUpdate
 from ibis import _
 from psycopg_pool import ConnectionPool
 import dash_bootstrap_components as dbc
@@ -17,10 +18,13 @@ from ssb_dash_framework.utils.config_tools.set_variables import get_refnr
 from ssb_dash_framework.utils.config_tools.set_variables import get_time_units
 
 from ssb_dash_framework.utils.config_tools.set_variables import get_ident
-from ssb_dash_framework.utils.core_query_functions import create_filter_dict, ibis_filter_with_dict
+from ssb_dash_framework.utils.core_query_functions import (
+    create_filter_dict,
+    ibis_filter_with_dict,
+)
 
-from  ssb_dash_framework.utils.config_tools.connection import _get_connection_object
-from  ssb_dash_framework.utils.config_tools.connection import get_connection
+from ssb_dash_framework.utils.config_tools.connection import _get_connection_object
+from ssb_dash_framework.utils.config_tools.connection import get_connection
 from ..core import DataEditorHelperButton
 
 logger = logging.getLogger(__name__)
@@ -55,7 +59,9 @@ class DataEditorContactInfo(DataEditorHelperButton):
 
         self.module_callbacks()
 
-    def create_info_card(self, title: str, component_id: str, var_type: str):
+    def create_info_card(
+        self, title: str, component_id: str, var_type: str, style: dict | None = None
+    ):
         card_info = html.Div(
             className="ssb-input",
             children=[
@@ -66,6 +72,8 @@ class DataEditorContactInfo(DataEditorHelperButton):
                         dbc.Input(
                             id=component_id,
                             type=var_type,
+                            style=style,
+                            readonly=True,
                         )
                     ],
                 ),
@@ -93,15 +101,16 @@ class DataEditorContactInfo(DataEditorHelperButton):
                                     component_id="dataeditor-kontaktinfo-card-skjema",
                                     var_type="text",
                                 ),
-                                width=2,
+                                width=1,
                             ),
+                            
                             dbc.Col(
                                 self.create_info_card(
                                     title="Kontaktperson",
                                     component_id="dataeditor-kontaktinfo-card-kontaktperson",
-                                    var_type="number",
+                                    var_type="text",
                                 ),
-                                width=2,
+                                width=3,
                             ),
                             dbc.Col(
                                 self.create_info_card(
@@ -109,7 +118,7 @@ class DataEditorContactInfo(DataEditorHelperButton):
                                     component_id="dataeditor-kontaktinfo-card-epost",
                                     var_type="text",
                                 ),
-                                width=2,
+                                width=3,
                             ),
                             dbc.Col(
                                 self.create_info_card(
@@ -117,41 +126,78 @@ class DataEditorContactInfo(DataEditorHelperButton):
                                     component_id="dataeditor-kontaktinfo-card-tlf",
                                     var_type="text",
                                 ),
+                                width=1,
+                            ),
+                            dbc.Col(
+                                html.Div(
+                                    [
+                                        html.Label(
+                                            "Kontaktinfo bekreftet?",
+                                            style={"visibility": "visible"},
+                                        ),
+                                        html.Div(
+                                            className="ssb-checkbox d-flex align-items-center",
+                                            children=[
+                                                dcc.Checklist(
+                                                    id="dataeditor-kontaktinfo-bekreftet",
+                                                    options=[
+                                                        {"label": "", "value": "1", "disabled": True}
+                                                    ],
+                                                    value=[],
+                                                ),
+                                            ],
+                                            style={"height": "44px"},
+                                        ),
+                                    ],
+                                    className="ssb-input",
+                                ),
                                 width=2,
                             ),
                         ],
-                        className="g-2 align-items-end",
+                        className="mb-2",
                     ),
                     dbc.Row(
                         [
                             dbc.Col(
-                                self.create_info_card(
-                                    title="Kommentar kontaktinfo",
-                                    component_id="dataeditor-kontaktinfo-card-kommentar",
-                                    var_type="text",
-                                ),
-                                width=2,
+                                [
+                                    html.Label(
+                                        "Generell kommentar",
+                                        className="ssb-input",
+                                    ),
+                                    dbc.Textarea(
+                                        id="dataeditor-kontaktinfo-card-kommentar",
+                                        className="microlayout-textarea-field",
+                                        readonly=True,
+                                    ),
+                                ],
+                                className="microlayout-textarea",
                             ),
                             dbc.Col(
-                                self.create_info_card(
-                                    title="Kommentar krevende",
-                                    component_id="dataeditor-kontaktinfo-card-krevende",
-                                    var_type="text",
-                                ),
-                                width=2,
+                                [
+                                    html.Label(
+                                        "Kommentar krevende",
+                                        className="ssb-input",
+                                    ),
+                                    dbc.Textarea(
+                                        id="dataeditor-kontaktinfo-card-krevende",
+                                        className="microlayout-textarea-field",
+                                        readonly=True,
+                                    ),
+                                ],
+                                className="microlayout-textarea",
                             ),
                         ],
-                        className="g-2 align-items-end",
+                        className="mb-2",
                     ),
-                ]
+                ],
+                className=f"{self.module_name}-body",
             ),
-            className=f"{self.module_name}-body",
         )
 
     def module_callbacks(self):
         connection_object = _get_connection_object()
         variableselector = VariableSelector(
-            selected_inputs=["ident", *get_time_units().keys()],
+            selected_inputs=["refnr"],
             selected_states=[],
         )
 
@@ -160,50 +206,77 @@ class DataEditorContactInfo(DataEditorHelperButton):
                 component_id="dataeditor-kontaktinfo-card-organisasjonsnummer",
                 component_property="value",
             ),
-            Output(component_id="dataeditor-kontaktinfo-card-skjema", component_property="value"),
+            Output(
+                component_id="dataeditor-kontaktinfo-card-skjema",
+                component_property="value",
+            ),
             Output(
                 component_id="dataeditor-kontaktinfo-card-kontaktperson",
                 component_property="value",
             ),
             Output(
-                component_id="dataeditor-kontaktinfo-card-epost", component_property="value"
+                component_id="dataeditor-kontaktinfo-card-epost",
+                component_property="value",
             ),
-            Output(component_id="dataeditor-kontaktinfo-card-tlf", component_property="value"),
-            Output(component_id="dataeditor-kontaktinfo-card-kommentar", component_property="value"),
             Output(
-                component_id="dataeditor-kontaktinfo-card-krevende", component_property="value"
+                component_id="dataeditor-kontaktinfo-card-tlf",
+                component_property="value",
             ),
-            variableselector.get_input(get_ident()),
-            *[variableselector.get_input(unit) for unit in get_time_units().keys()],
-
+            Output(
+                component_id="dataeditor-kontaktinfo-bekreftet",
+                component_property="value",
+            ),
+            Output(
+                component_id="dataeditor-kontaktinfo-card-kommentar",
+                component_property="value",
+            ),
+            Output(
+                component_id="dataeditor-kontaktinfo-card-krevende",
+                component_property="value",
+            ),
+            Output(
+                component_id=f"{self.module_name}-{self.module_number}-indicator",
+                component_property="style",
+            ),
+            Output(
+                component_id=f"{self.module_name}-{self.module_number}-indicator",
+                component_property="children",
+            ),
+            variableselector.get_input(get_refnr()),
         )
-        def create_info_cards_kontaktinfo(ident: str, *args: Any) -> tuple[str, str, str, str, str, str, str]:
+        def create_info_cards_kontaktinfo(
+            refnr: str,
+        ) -> tuple[str, str, str, str, str, list[str], str, str, dict[str, str], str]:
             """Returns a tuple of strings with the values for info cards for the kontaktinfo module in DataEditor.
             These cards will hold kontaktinfo foretak.
             """
-            time_unit_list = [x for x in get_time_units().keys()]
-            time_units = args[: len(time_unit_list)]
-            print(time_units)
-
-            filter_dict = create_filter_dict(time_unit_list, time_units)
-            print(filter_dict)
+            if not refnr:
+                raise PreventUpdate
 
             if isinstance(connection_object, ConnectionPool):
                 logger.debug("Using ConnectionPool logic.")
                 with get_connection(necessary_tables=["kontaktinfo"]) as conn:
                     t = conn.table("kontaktinfo")
-                    data = t.filter(_.ident == ident).filter(
-                            ibis_filter_with_dict(filter_dict)
-                        ).execute()
-                print(data)
+                    data = t.filter(_.refnr == refnr).execute()
 
                 orgnr = data["ident"].iloc[0]
                 skjema = data["skjema"].iloc[0]
                 kontaktperson = data["kontaktperson"].iloc[0]
                 epost = data["epost"].iloc[0]
                 tlf = data["telefon"].iloc[0]
+                bekreftet = data["bekreftet_kontaktinfo"].iloc[0]
                 kommentar_kontaktinfo = data["kommentar_kontaktinfo"].iloc[0]
                 kommentar_krevende = data["kommentar_krevende"].iloc[0]
+                comment_count = sum(
+                    [
+                        bool(kommentar_kontaktinfo),
+                        bool(kommentar_krevende),
+                    ]
+                )
+                indicator_style = (
+                    {"display": "block"} if comment_count > 0 else {"display": "none"}
+                )
+                print(f"comment_count: {comment_count}")
 
                 return (
                     orgnr,
@@ -211,8 +284,11 @@ class DataEditorContactInfo(DataEditorHelperButton):
                     kontaktperson,
                     epost,
                     tlf,
+                    [bekreftet] if bekreftet else [],
                     kommentar_kontaktinfo,
                     kommentar_krevende,
+                    indicator_style,
+                    str(comment_count) if comment_count > 0 else "",
                 )
 
             else:

--- a/src/ssb_dash_framework/experimental/modules/data_editor/helper_buttons/contact_info.py
+++ b/src/ssb_dash_framework/experimental/modules/data_editor/helper_buttons/contact_info.py
@@ -60,7 +60,7 @@ class DataEditorContactInfo(DataEditorHelperButton):
         self.module_callbacks()
 
     def create_info_card(
-        self, title: str, component_id: str, var_type: str, style: dict | None = None
+        self, title: str, component_id: str, var_type: str | int, style: dict | None = None
     ):
         card_info = html.Div(
             className="ssb-input",
@@ -259,14 +259,14 @@ class DataEditorContactInfo(DataEditorHelperButton):
                     t = conn.table("kontaktinfo")
                     data = t.filter(_.refnr == refnr).execute()
 
-                orgnr = data["ident"].iloc[0]
-                skjema = data["skjema"].iloc[0]
-                kontaktperson = data["kontaktperson"].iloc[0]
-                epost = data["epost"].iloc[0]
-                tlf = data["telefon"].iloc[0]
-                bekreftet = data["bekreftet_kontaktinfo"].iloc[0]
-                kommentar_kontaktinfo = data["kommentar_kontaktinfo"].iloc[0]
-                kommentar_krevende = data["kommentar_krevende"].iloc[0]
+                orgnr = data["ident"].item()
+                skjema = data["skjema"].item()
+                kontaktperson = data["kontaktperson"].item()
+                epost = data["epost"].item()
+                tlf = data["telefon"].item()
+                bekreftet = data["bekreftet_kontaktinfo"].item()
+                kommentar_kontaktinfo = data["kommentar_kontaktinfo"].item()
+                kommentar_krevende = data["kommentar_krevende"].item()
                 comment_count = sum(
                     [
                         bool(kommentar_kontaktinfo),

--- a/src/ssb_dash_framework/utils/core_query_functions.py
+++ b/src/ssb_dash_framework/utils/core_query_functions.py
@@ -49,7 +49,7 @@ def ibis_filter_with_dict(periods_dict: dict[str, Any]) -> list[Any]:
         t.filter(ibis_filter_with_dict(filter_dict))
     """
     filters = []
-    print("Filtrerings dict")
+    logger.debug("Filtrerings dict")
     for key, value in periods_dict.items():
         col = getattr(_, key)
         if isinstance(value, list):
@@ -57,7 +57,7 @@ def ibis_filter_with_dict(periods_dict: dict[str, Any]) -> list[Any]:
         else:
             expr = col == value
         filters.append(expr)
-    print(filters)
+    logger.debug(filters)
     return filters
 
 


### PR DESCRIPTION
- Added a button to view contact info from Altinn3 in the new DataEditor
- If comments related to the skjema or "kommentar krevende" have been sent in with the skjema, an indicator with a counter on it will let the user know. It also tells you how many comments are available. These are sometimes important so the user has to see them:
<img width="369" height="171" alt="image" src="https://github.com/user-attachments/assets/33ee4bf7-f0f7-4f33-8319-6505a0c40fd7" />

- Added the indicator-option to the DataEditorHelperButton class. It uses the specified "SSB Design" blue to be used for info.
