### PR TITLE
fix: close psycopg_pool pools on exit and stop holding a long-lived n…

### DIFF
--- a/src/ssb_dash_framework/modules/nspek/nspek.py
+++ b/src/ssb_dash_framework/modules/nspek/nspek.py
@@ -20,7 +20,6 @@ from dash.exceptions import PreventUpdate
 from dash_ag_grid import AgGrid
 from dash_iconify import DashIconify
 from ibis import _
-from ibis.backends import BaseBackend
 from pandas.core.frame import DataFrame
 
 from ...setup.variableselector import VariableSelector
@@ -399,7 +398,7 @@ TYPE_REGNSKAP_TABLE = {  # type: {database: exampleregnskap, table: tema_example
 def get_versions(conn, ident: str, aar: str) -> pd.DataFrame:
     """Fetch and return pandas dataframe containing all sekvensnummer sorted by versjon_nr from nspek_core view v_registrering_versjon.
 
-    Example use: get_versions(self.conn, "979443137", "2024")
+    Example use: get_versions(conn, "979443137", "2024")
     """
     config = TYPE_REGNSKAP_TABLE["v_registrering_versjon"]
 
@@ -427,7 +426,7 @@ def get_virksomhetsinfo(
 ) -> pd.DataFrame:
     """Fetch and return pandas dataframe containing virksomhetsinfo from nspek files for specified variables for a unit.
 
-    Example use: get_virksomhetsinfo(self.conn, virksomhetsinfo_variabler, "979443137", "2024", 2291859)
+    Example use: get_virksomhetsinfo(conn, virksomhetsinfo_variabler, "979443137", "2024", 2291859)
     """
     config = TYPE_REGNSKAP_TABLE["virksomhet"]
 
@@ -650,7 +649,7 @@ def fetch_data_by_orgnr(
 ) -> pd.DataFrame:
     """Returns a pandas dataframe with all nspek values found in the specified regnskapstype for a unit/orgnr.
 
-    Example use: fetch_data_by_orgnr(self.conn, "resultatregnskap", "932598957", "2024", 2291859)
+    Example use: fetch_data_by_orgnr(conn, "resultatregnskap", "932598957", "2024", 2291859)
     """
     config = TYPE_REGNSKAP_TABLE[regnskapstype]
 
@@ -964,7 +963,6 @@ class Naeringsspesifikasjon:
         self.icon = "📒"
         self.label = "NSPEK"
 
-        self.conn: BaseBackend = get_nspek_connection().__enter__()
         self.variableselector = VariableSelector(
             selected_inputs=time_units, selected_states=[]
         )
@@ -1969,16 +1967,17 @@ class Naeringsspesifikasjon:
             if not aar or not orgnr_foretak or not sekvensnummer:
                 return "", "", "", "", ""
 
-            if not has_data(self.conn, orgnr_foretak, aar):
-                return "", "", "", "", ""
+            with get_nspek_connection() as conn:
+                if not has_data(conn, orgnr_foretak, aar):
+                    return "", "", "", "", ""
 
-            df = get_virksomhetsinfo(
-                conn=self.conn,
-                variables_to_fetch=virksomhetsinfo_variabler,
-                ident=orgnr_foretak,
-                aar=aar,
-                sekvensnummer=sekvensnummer,
-            )
+                df = get_virksomhetsinfo(
+                    conn=conn,
+                    variables_to_fetch=virksomhetsinfo_variabler,
+                    ident=orgnr_foretak,
+                    aar=aar,
+                    sekvensnummer=sekvensnummer,
+                )
 
             if df.empty:
                 return "", "", "", "", ""
@@ -2028,9 +2027,10 @@ class Naeringsspesifikasjon:
                 return [], []
 
             post_descriptions = post_description_data("balanseregnskap")
-            ident_data = fetch_data_by_orgnr(
-                self.conn, "balanseregnskap", orgnr_foretak, aar, sekvensnummer
-            )
+            with get_nspek_connection() as conn:
+                ident_data = fetch_data_by_orgnr(
+                    conn, "balanseregnskap", orgnr_foretak, aar, sekvensnummer
+                )
 
             post_descriptions["felt"] = post_descriptions["felt"].astype(str)
             ident_data["felt"] = ident_data["felt"].astype(str)
@@ -2042,9 +2042,10 @@ class Naeringsspesifikasjon:
             )
 
             if sekvens_compare:
-                df_compare = fetch_data_by_orgnr(
-                    self.conn, "balanseregnskap", orgnr_foretak, aar, sekvens_compare
-                )
+                with get_nspek_connection() as conn:
+                    df_compare = fetch_data_by_orgnr(
+                        conn, "balanseregnskap", orgnr_foretak, aar, sekvens_compare
+                    )
                 df_compare = df_compare.rename(
                     columns={
                         "tekst": "beskrivelse",
@@ -2069,7 +2070,8 @@ class Naeringsspesifikasjon:
             df = apply_blank_filter(df, toggle_blank)
             df = apply_petroleum_filter(df, orgnr_foretak, toggle_petroleum)
 
-            comments = get_latest_field_comments(self.conn, orgnr_foretak)
+            with get_nspek_connection() as conn:
+                comments = get_latest_field_comments(conn, orgnr_foretak)
             df["comment_icon"] = df["post"].map(lambda x: "💬" if x in comments else "")
             df["comment_text"] = df["post"].map(
                 lambda x: comments.get(x, {}).get("kommentar", "")
@@ -2113,9 +2115,10 @@ class Naeringsspesifikasjon:
                 return [], []
 
             post_descriptions = post_description_data("resultatregnskap")
-            ident_data = fetch_data_by_orgnr(
-                self.conn, "resultatregnskap", orgnr_foretak, aar, sekvensnummer
-            )
+            with get_nspek_connection() as conn:
+                ident_data = fetch_data_by_orgnr(
+                    conn, "resultatregnskap", orgnr_foretak, aar, sekvensnummer
+                )
 
             post_descriptions["felt"] = post_descriptions["felt"].astype(str)
             ident_data["felt"] = ident_data["felt"].astype(str)
@@ -2127,9 +2130,10 @@ class Naeringsspesifikasjon:
             )
 
             if sekvens_compare:
-                df_compare = fetch_data_by_orgnr(
-                    self.conn, "resultatregnskap", orgnr_foretak, aar, sekvens_compare
-                )
+                with get_nspek_connection() as conn:
+                    df_compare = fetch_data_by_orgnr(
+                        conn, "resultatregnskap", orgnr_foretak, aar, sekvens_compare
+                    )
                 df_compare = df_compare.rename(
                     columns={
                         "tekst": "beskrivelse",
@@ -2154,7 +2158,8 @@ class Naeringsspesifikasjon:
             df = apply_blank_filter(df, toggle_blank)
             df = apply_petroleum_filter(df, orgnr_foretak, toggle_petroleum)
 
-            comments = get_latest_field_comments(self.conn, orgnr_foretak)
+            with get_nspek_connection() as conn:
+                comments = get_latest_field_comments(conn, orgnr_foretak)
             df["comment_icon"] = df["post"].map(lambda x: "💬" if x in comments else "")
             df["comment_text"] = df["post"].map(
                 lambda x: comments.get(x, {}).get("kommentar", "")
@@ -2354,7 +2359,10 @@ class Naeringsspesifikasjon:
                     ],
                 )
 
-            if not has_data(self.conn, orgnr, aar):
+            with get_nspek_connection() as conn:
+                nspek_has_data = has_data(conn, orgnr, aar)
+
+            if not nspek_has_data:
                 refresh_data = trigger_refresh(refresh_data, "invalid_search")
                 return (
                     no_update,
@@ -2385,23 +2393,25 @@ class Naeringsspesifikasjon:
             if not orgnr or not aar:
                 raise PreventUpdate
 
-            if not has_data(self.conn, orgnr, aar):
-                return [], None
+            with get_nspek_connection() as conn:
+                if not has_data(conn, orgnr, aar):
+                    return [], None
 
-            df = get_versions(self.conn, orgnr, aar)
+                df = get_versions(conn, orgnr, aar)
 
             if df.empty:
                 return [], None
 
             sekvens_liste = df["sekvensnummer"].tolist()
 
-            t = self.conn.table("v_update_counts", database="nspek_core")
+            with get_nspek_connection() as conn:
+                t = conn.table("v_update_counts", database="nspek_core")
 
-            df_updates = (
-                t.filter(_.sekvensnummer.isin(sekvens_liste))
-                .select(_.sekvensnummer, _.antall_endringer)
-                .execute()
-            )
+                df_updates = (
+                    t.filter(_.sekvensnummer.isin(sekvens_liste))
+                    .select(_.sekvensnummer, _.antall_endringer)
+                    .execute()
+                )
 
             df = df.merge(df_updates, on="sekvensnummer", how="left")
             df["antall_endringer"] = df["antall_endringer"].fillna(0)
@@ -2446,10 +2456,11 @@ class Naeringsspesifikasjon:
             if not selected_sekvens or not orgnr or not aar:
                 return {"display": "none"}, "", False
 
-            if not has_data(self.conn, orgnr, aar):
-                return {"display": "none"}, "", False
+            with get_nspek_connection() as conn:
+                if not has_data(conn, orgnr, aar):
+                    return {"display": "none"}, "", False
 
-            df = get_versions(self.conn, orgnr, aar)
+                df = get_versions(conn, orgnr, aar)
 
             if df.empty:
                 return {"display": "none"}, "", False
@@ -3127,7 +3138,10 @@ class Naeringsspesifikasjon:
             if not orgnr or not aar:
                 raise PreventUpdate
 
-            if not has_data(self.conn, orgnr, aar):
+            with get_nspek_connection() as conn:
+                nspek_has_data = has_data(conn, orgnr, aar)
+
+            if not nspek_has_data:
 
                 refresh_data = trigger_refresh(refresh_data, "invalid_search")
 

--- a/src/ssb_dash_framework/modules/nspek/nspek_utils.py
+++ b/src/ssb_dash_framework/modules/nspek/nspek_utils.py
@@ -1,3 +1,4 @@
+import atexit
 from collections.abc import Callable
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -33,8 +34,27 @@ def set_nspek_connection(database_user: str | None = None) -> None:
 
     _IS_POOLED_NSPEK = True
 
+    # If a previous call already configured a pool, close it and drop its exit
+    # hook so exactly one pool (and one atexit handler) is ever live. Safe
+    # because every caller borrows connections through short-lived
+    # ``with get_nspek_connection() as conn:`` blocks -- nothing holds a pooled
+    # connection across this reconfiguration.
+    if isinstance(_CONNECTION_NSPEK, ConnectionPool):
+        atexit.unregister(_CONNECTION_NSPEK.close)
+        _CONNECTION_NSPEK.close()
+
     pool = ConnectionPool(conninfo=conn_url, min_size=1, max_size=1)
     _CONNECTION_NSPEK = pool
+
+    # psycopg_pool opens daemon worker ('pool-N-worker-M') and scheduler
+    # threads as soon as the pool is created. If the pool is never closed those
+    # threads are still running at interpreter shutdown, and psycopg_pool warns
+    # "couldn't stop thread 'pool-1-worker-0' within 5.0 seconds" on exit (e.g.
+    # when the app is stopped with Ctrl+C). Closing the pool on exit stops them
+    # cleanly. ConnectionPool.close() is idempotent, so explicit closes
+    # elsewhere stay safe. Registered before the validation below so the pool is
+    # still cleaned up if connecting fails.
+    atexit.register(pool.close)
 
     @contextmanager
     def _wrap_ibis_postgres(*args: Any, **kwargs: Any) -> Iterator[BaseBackend]:

--- a/src/ssb_dash_framework/utils/config_tools/connection.py
+++ b/src/ssb_dash_framework/utils/config_tools/connection.py
@@ -1,3 +1,4 @@
+import atexit
 from collections.abc import Callable
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
@@ -107,6 +108,15 @@ def set_postgres_connection(
     global _IS_POOLED, _CONNECTION, _CONNECTION_CALLABLE
     _IS_POOLED = True
 
+    # If a previous call already configured a pool, close it and drop its exit
+    # hook so exactly one pool (and one atexit handler) is ever live. Safe
+    # because every caller borrows connections through short-lived
+    # ``with get_connection() as conn:`` blocks -- nothing holds a pooled
+    # connection across this reconfiguration.
+    if isinstance(_CONNECTION, ConnectionPool):
+        atexit.unregister(_CONNECTION.close)
+        _CONNECTION.close()
+
     pool = ConnectionPool(
         conninfo=database_url,
         min_size=pool_min_size,
@@ -114,6 +124,16 @@ def set_postgres_connection(
         configure=configure,
     )
     _CONNECTION = pool
+
+    # psycopg_pool opens daemon worker ('pool-N-worker-M') and scheduler
+    # threads as soon as the pool is created. If the pool is never closed those
+    # threads are still running at interpreter shutdown, and psycopg_pool warns
+    # "couldn't stop thread 'pool-1-worker-0' within 5.0 seconds" on exit (e.g.
+    # when the app is stopped with Ctrl+C). Closing the pool on exit stops them
+    # cleanly. ConnectionPool.close() is idempotent, so explicit closes
+    # elsewhere stay safe. Registered before the validation below so the pool is
+    # still cleaned up if connecting fails.
+    atexit.register(pool.close)
 
     @contextmanager
     def _wrap_ibis_postgres(*args: Any, **kwargs: Any) -> Iterator[BaseBackend]:

--- a/src/ssb_dash_framework/utils/config_tools/connection.py
+++ b/src/ssb_dash_framework/utils/config_tools/connection.py
@@ -13,7 +13,7 @@ from psycopg import Connection
 from psycopg_pool import ConnectionPool
 
 _IS_POOLED: bool | None = None
-_CONNECTION: object | None = None
+_CONNECTION: ConnectionPool | None = None
 _CONNECTION_CALLABLE: Callable[..., Any] | None = None
 
 

--- a/src/ssb_dash_framework/utils/config_tools/connection.py
+++ b/src/ssb_dash_framework/utils/config_tools/connection.py
@@ -113,7 +113,7 @@ def set_postgres_connection(
     # because every caller borrows connections through short-lived
     # ``with get_connection() as conn:`` blocks -- nothing holds a pooled
     # connection across this reconfiguration.
-    if isinstance(_CONNECTION, ConnectionPool):
+    if _CONNECTION is not None:
         atexit.unregister(_CONNECTION.close)
         _CONNECTION.close()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,10 +2,10 @@
 
 from unittest.mock import patch
 import pytest
+from psycopg_pool import ConnectionPool
 
 from ssb_dash_framework.utils.config_tools import connection
 
-# reset _CONNECTION in between tests
 @pytest.fixture(autouse=True)
 def reset_connection_state():
     connection._CONNECTION = None
@@ -19,7 +19,7 @@ def test_set_postgres_connection_forwards_configure_callback() -> None:
         pass
 
     with (
-        patch.object(connection, "ConnectionPool") as pool_cls,
+        patch.object(connection, "ConnectionPool", spec=ConnectionPool) as pool_cls,
         patch.object(connection, "set_connection"),
     ):
         connection.set_postgres_connection(
@@ -40,7 +40,7 @@ def test_set_postgres_connection_forwards_configure_callback() -> None:
 def test_set_postgres_connection_defaults_configure_to_none() -> None:
     """Existing callers that omit ``configure`` still pass ``configure=None`` (no-op)."""
     with (
-        patch.object(connection, "ConnectionPool") as pool_cls,
+        patch.object(connection, "ConnectionPool", spec=ConnectionPool) as pool_cls,
         patch.object(connection, "set_connection"),
     ):
         connection.set_postgres_connection(database_url="postgresql://example")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,9 +1,16 @@
 """Tests for ``set_postgres_connection``'s optional per-connection ``configure`` hook."""
 
 from unittest.mock import patch
+import pytest
 
 from ssb_dash_framework.utils.config_tools import connection
 
+# reset _CONNECTION in between tests
+@pytest.fixture(autouse=True)
+def reset_connection_state():
+    connection._CONNECTION = None
+    yield
+    connection._CONNECTION = None
 
 def test_set_postgres_connection_forwards_configure_callback() -> None:
     """A provided ``configure`` callback is passed straight through to ConnectionPool."""


### PR DESCRIPTION
# Fix psycopg_pool worker-thread shutdown warning & NSPEK connection-lifecycle bug

## Summary
This PR stops the noisy, repeated warning that `psycopg_pool` prints to the
terminal whenever an app using this framework is shut down (e.g. with `Ctrl+C`):

```
couldn't stop thread 'pool-1-worker-0' within 5.0 seconds
hint: you can try to call 'close()' explicitly or to use the pool as context manager
```

The root cause is that the framework creates `psycopg_pool.ConnectionPool`
objects but never closes them, so the pool's background threads are still
running at interpreter shutdown. While investigating, a second, related
connection-lifecycle bug was found in the NSPEK module (a pooled connection held
for the entire app lifetime and never returned). Both are fixed here.

These changes are independent of the earlier "host/port/database configurable" /
`FATAL: database "nspek" does not exist` work - that behaviour is intentional for
users outside the `nspek-developers` / `strukt-naering-developers` groups and is
unchanged.

## Changes Made

**`src/ssb_dash_framework/utils/config_tools/connection.py`**
- `set_postgres_connection()` now registers `pool.close()` via `atexit`, so the
  pool's daemon worker/scheduler threads are stopped cleanly on shutdown.
- Before creating a new pool, it now closes and `atexit.unregister()`s any
  previously configured pool, so exactly one pool (and one exit handler) is ever
  live.
- Added `import atexit`.

**`src/ssb_dash_framework/modules/nspek/nspek_utils.py`**
- Identical treatment for `set_nspek_connection()` (the NSPEK-specific pool
  setter): `atexit`-registered `close()`, plus close + unregister of any prior
  pool. Added `import atexit`.

**`src/ssb_dash_framework/modules/nspek/nspek.py`**
- Removed the long-lived `self.conn = get_nspek_connection().__enter__()` in
  `Naeringsspesifikasjon.__init__` (a context manager that was never exited).
- Refactored all 7 callbacks that used `self.conn` to borrow and return a
  connection per use via `with get_nspek_connection() as conn:`, matching the
  ~10 call sites in the module that already do this.
- Removed the now-unused `from ibis.backends import BaseBackend` import and
  updated 3 helper docstrings that referenced `self.conn`.

## Why These Changes Were Needed

**1. Pool threads never stopped (the reported bug).**
`psycopg_pool.ConnectionPool` spawns daemon threads (`pool-N-worker-M` and a
`pool-N-scheduler`) the moment it is created. The framework stored each pool in a
module global and never called `.close()`. At interpreter shutdown,
`ConnectionPool.__del__` tries to join those threads within a 5-second timeout,
fails, and prints the warning above - once per thread, every time the app is
stopped. The library's own hint is literally *"call `close()` explicitly."*

**2. NSPEK held a pooled connection for the whole app lifetime.**
`Naeringsspesifikasjon.__init__` did:

```python
self.conn = get_nspek_connection().__enter__()
```

This manually entered the connection context manager but never exited it,
permanently borrowing the single connection from the `min_size=1, max_size=1`
pool and relying on garbage collection of the orphaned generator to release it.
That one `self.conn` was then shared across Dash callbacks, which run
concurrently in worker threads - a `psycopg` connection is not safe for
concurrent use, so this was a latent correctness/threading hazard in addition to
the lifecycle leak.

## Implementation Details

- **Why `atexit` fixes the warning:** `ConnectionPool.close()` sets the pool's
  internal `_closed` flag. `ConnectionPool.__del__` early-returns when `_closed`
  is true, so the 5-second join-and-warn path never executes. `atexit` handlers
  run on normal interpreter exit - including after a `Ctrl+C` `KeyboardInterrupt`
  that propagates to the top - *before* the shutdown garbage collection that
  would otherwise trigger `__del__`. Confirmed against `psycopg_pool` 3.3.0.
- **Why close+unregister the previous pool is safe now:** it is only safe because
  the NSPEK refactor removed the one place that held a pooled connection across a
  reconfiguration. All connections are now borrowed inside short-lived `with`
  blocks, and module `__init__`s (the only callers of the setters) run at app
  startup before any callback fires. `atexit.unregister(old_pool.close)` reliably
  removes the prior handler (verified via observed at-exit firing - bound-method
  equality matches).
- **Per-use connection scoping:** every helper (`has_data`, `get_versions`,
  `get_virksomhetsinfo`, `fetch_data_by_orgnr`, `get_latest_field_comments`)
  returns a **materialized** pandas `DataFrame` / `dict` / `bool`, so results are
  safe to use after the `with` block closes. The only lazy Ibis expression
  (`conn.table(...).filter(...).select(...).execute()` in `load_versions`) keeps
  its `.execute()` **inside** the `with` block.
- **No deadlock:** within any single callback the `with` blocks are sequential,
  never nested, and no helper opens its own connection - so the `max_size=1` pool
  is never asked for a second connection while one is held.

## Code Changes

**Pool cleanup - `src/ssb_dash_framework/utils/config_tools/connection.py`**
(`set_postgres_connection`, around lines 108–136; `nspek_utils.py`’s
`set_nspek_connection` mirrors this at lines 34–57):

```diff
+import atexit
 from collections.abc import Callable
 from collections.abc import Iterator
@@ def set_postgres_connection(...):
     global _IS_POOLED, _CONNECTION, _CONNECTION_CALLABLE
     _IS_POOLED = True
 
+    # Close + drop the exit hook of any previously configured pool so exactly
+    # one pool (and one atexit handler) is ever live.
+    if isinstance(_CONNECTION, ConnectionPool):
+        atexit.unregister(_CONNECTION.close)
+        _CONNECTION.close()
+
     pool = ConnectionPool(
         conninfo=database_url,
         min_size=pool_min_size,
         max_size=pool_max_size,
         configure=configure,
     )
     _CONNECTION = pool
 
+    # psycopg_pool opens daemon worker/scheduler threads on creation; if the
+    # pool is never closed they cannot be joined at shutdown and psycopg_pool
+    # warns "couldn't stop thread 'pool-1-worker-0' within 5.0 seconds".
+    # Closing on exit stops them cleanly (close() is idempotent).
+    atexit.register(pool.close)
```

**NSPEK lifecycle - `src/ssb_dash_framework/modules/nspek/nspek.py`**

Removed the unused import and the long-lived connection in
`Naeringsspesifikasjon.__init__` (~line 956):

```diff
-from ibis.backends import BaseBackend
```

```diff
         self.label = "NSPEK"
 
-        self.conn: BaseBackend = get_nspek_connection().__enter__()
         self.variableselector = VariableSelector(
             selected_inputs=time_units, selected_states=[]
         )
```

Representative callback refactor - `load_versions` (~lines 2393–2414), which
contains the only lazy Ibis chain (note `.execute()` stays inside the `with`):

```diff
-            if not has_data(self.conn, orgnr, aar):
-                return [], None
-
-            df = get_versions(self.conn, orgnr, aar)
+            with get_nspek_connection() as conn:
+                if not has_data(conn, orgnr, aar):
+                    return [], None
+
+                df = get_versions(conn, orgnr, aar)
 
             if df.empty:
                 return [], None
 
             sekvens_liste = df["sekvensnummer"].tolist()
 
-            t = self.conn.table("v_update_counts", database="nspek_core")
-
-            df_updates = (
-                t.filter(_.sekvensnummer.isin(sekvens_liste))
-                .select(_.sekvensnummer, _.antall_endringer)
-                .execute()
-            )
+            with get_nspek_connection() as conn:
+                t = conn.table("v_update_counts", database="nspek_core")
+
+                df_updates = (
+                    t.filter(_.sekvensnummer.isin(sekvens_liste))
+                    .select(_.sekvensnummer, _.antall_endringer)
+                    .execute()
+                )
```

The same per-use `with get_nspek_connection() as conn:` pattern was applied in
`create_info_cards_virksomhet`, `show_balanseregnskap`, `show_resultatregnskap`,
the orgnr-validation callback, `toggle_version_warning`, and
`validate_nspek_data_exists`.

## Testing / Validation
- `python -m py_compile` and importing all three modules succeed.
- Verified against `psycopg_pool` 3.3.0 that `close()` sets `_closed`, which
  makes `ConnectionPool.__del__` early-return - i.e. closing the pool removes the
  exact code path that prints the warning.
- Verified `atexit` fires on normal/`Ctrl+C` exit and that
  `atexit.unregister(pool.close)` removes the previous pool's handler (observed
  by which handlers actually fire at process exit).
- Verified the reconfiguration logic: calling the setter repeatedly leaves
  exactly one open pool, with all prior pools closed.
- Adversarial multi-agent review of the full diff confirmed: every `conn` use
  (including the lazy Ibis chain) executes inside an open connection scope, all
  helper return values are materialized, no callback nests connection borrows
  (no `max_size=1` deadlock), and control flow/early-returns are unchanged.
- **Not** tested: running the full Dash app against a live NSPEK Postgres
  database - this environment has no access to it. Manual smoke-testing against
  the `nspek` database (load a unit, view balanse/resultat grids, switch
  versions, then `Ctrl+C`) is recommended before merge.

## Reviewer Notes
- **Possible behaviour change:** the public-ish `self.conn` attribute on
  `Naeringsspesifikasjon` no longer exists. A repo-wide grep found no other
  reader, but if downstream code (e.g. `stat-naringer-dash`) accesses
  `instance.conn`, it must switch to `with get_nspek_connection() as conn:`.
- **Concurrency:** with `max_size=1`, concurrent callbacks now serialize briefly
  on connection acquisition instead of unsafely sharing one connection. If higher
  parallelism is wanted, raise `pool_max_size` in `set_nspek_connection`; the new
  per-use pattern is what makes that safe.
- **Out of scope (intentionally left untouched):** pre-existing lint/type
  warnings in `nspek.py` (commented-out code, high cognitive complexity, a
  `# type:` comment near line 398 that trips mypy) and the `set_nspek_connection`
  docstring that names `database_url` while the parameter is `database_user`.
- `atexit` does not run on `SIGKILL` / `os._exit()`; those are not the normal
  Dash shutdown path, so the warning fix covers the realistic cases.
