### PR TITLE
ssb-dropdown styling fix: Hide checkboxes for radio-button ssb-dropdowns (single-choice)

### DIFF
--- a/src/ssb_dash_framework/assets/stylesheet.css
+++ b/src/ssb_dash_framework/assets/stylesheet.css
@@ -991,8 +991,12 @@ ssb-dropdown
 .dash-dropdown-options .dash-options-list-option-wrapper {
   display: inline-flex;
   align-items: center;
-  margin-right: 10px;
-  padding: 10px;
+  padding: 5px;
+}
+
+
+.dash-dropdown-options .dash-options-list-option-checkbox[type="radio"] {
+  display: none;
 }
 
 .dash-dropdown-options .dash-options-list-option-checkbox {
@@ -1000,7 +1004,7 @@ ssb-dropdown
   -webkit-appearance: none;
   width: 18px;
   height: 18px;
-  margin: 0;
+  margin-left: 5px;
   border: 1px solid #162327;
   border-radius: 2px;
   border: 2px solid #274247;


### PR DESCRIPTION
- Keep only for dcc.Dropdown with className: ssb-dropdown with multiple choice option.